### PR TITLE
[#34] main page layout & scrolltoup 버튼

### DIFF
--- a/public/icons/ScrollToTopButton.svg
+++ b/public/icons/ScrollToTopButton.svg
@@ -1,0 +1,4 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="25" cy="25" r="25" transform="rotate(90 25 25)" fill="#66C57B"/>
+<path d="M35 30L25 20L15 30" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/button/scrollToTopButton.tsx
+++ b/src/components/button/scrollToTopButton.tsx
@@ -1,0 +1,16 @@
+import ScrollToTopButtonImg from '@/public/icons/ScrollToTopButton.svg';
+import Image from 'next/image';
+
+function ScrollToTopButton() {
+  return (
+    <div>
+      <Image
+        className="fixed right-50 bottom-80"
+        src={ScrollToTopButtonImg}
+        alt="페이지 상단으로 이동"
+      />
+    </div>
+  );
+}
+
+export default ScrollToTopButton;

--- a/src/components/button/scrollToTopButton.tsx
+++ b/src/components/button/scrollToTopButton.tsx
@@ -1,9 +1,20 @@
 import ScrollToTopButtonImg from '@/public/icons/ScrollToTopButton.svg';
+import { headerVisibleAtom } from '@/store/state';
+import { useAtom } from 'jotai';
 import Image from 'next/image';
 
 function ScrollToTopButton() {
+  const [headerVisible] = useAtom(headerVisibleAtom);
+
+  const handleClickToTopButton = () => {
+    if (!headerVisible) {
+      window.scrollTo({top:0, behavior:'smooth'})
+    }
+  }
+
   return (
-    <div>
+    !headerVisible &&
+    <div onClick={handleClickToTopButton} className='cursor-pointer'>
       <Image
         className="fixed right-50 bottom-80"
         src={ScrollToTopButtonImg}

--- a/src/components/button/scrollToTopButton.tsx
+++ b/src/components/button/scrollToTopButton.tsx
@@ -6,21 +6,21 @@ import Image from 'next/image';
 function ScrollToTopButton() {
   const [headerVisible] = useAtom(headerVisibleAtom);
 
-  const handleClickToTopButton = () => {
+  const handleClickScrollToTop = () => {
     if (!headerVisible) {
       window.scrollTo({top:0, behavior:'smooth'})
     }
   }
 
   return (
-    !headerVisible &&
-    <div onClick={handleClickToTopButton} className='cursor-pointer'>
+    headerVisible ? null :
+    <div onClick={handleClickScrollToTop} className='cursor-pointer'>
       <Image
         className="fixed right-50 bottom-80"
         src={ScrollToTopButtonImg}
         alt="페이지 상단으로 이동"
       />
-    </div>
+    </div> 
   );
 }
 

--- a/src/components/layout/headerLayout.tsx
+++ b/src/components/layout/headerLayout.tsx
@@ -1,9 +1,17 @@
 import Navigation from '@/components/header/navigation';
+import useInfinite from '@/hooks/useInfinite';
+import { headerVisibleAtom } from '@/store/state';
+import { useAtom } from 'jotai';
 import { ReactElement } from 'react';
 
 function HeaderLayout({ children }: { children: ReactElement }) {
+  const [ref, isIntersecting] = useInfinite();
+  const [, setHeaderVisible] = useAtom(headerVisibleAtom);
+
+  setHeaderVisible(isIntersecting);
+
   return (
-    <div className="flex-row h-90 tablet:h-170 pc:h-170">
+    <div className="flex-row h-90 tablet:h-170 pc:h-170" ref={ref}>
       {children} <Navigation />
     </div>
   );

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -1,0 +1,17 @@
+import Header from '@/components/header/index';
+import { ReactNode } from 'react';
+
+interface MainLayoutProps {
+  children: ReactNode;
+}
+
+function MainLayout({ children }: MainLayoutProps) {
+  return (
+    <>
+      <Header />
+      <div className="grid auto-rows-auto place-items-center">{children}</div>
+    </>
+  );
+}
+
+export default MainLayout;

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -9,7 +9,7 @@ interface MainLayoutProps {
 function MainLayout({ children }: MainLayoutProps) {
   return (
     <>
-      <Header />
+      <Header isLoggedIn={true} numItemsOfCart={1} />
       <div className="relative grid auto-rows-auto place-items-center tablet:max-w-[768px]">
         {children}
         <ScrollToTopButton />

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -10,7 +10,7 @@ function MainLayout({ children }: MainLayoutProps) {
   return (
     <>
       <Header />
-      <div className="relative grid auto-rows-auto place-items-center">
+      <div className="relative grid auto-rows-auto place-items-center tablet:max-w-[768px]">
         {children}
         <ScrollToTopButton />
       </div>

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -1,5 +1,6 @@
 import Header from '@/components/header/index';
 import { ReactNode } from 'react';
+import ScrollToTopButton from '@/components/button/scrollToTopButton';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -9,7 +10,10 @@ function MainLayout({ children }: MainLayoutProps) {
   return (
     <>
       <Header />
-      <div className="grid auto-rows-auto place-items-center">{children}</div>
+      <div className="relative grid auto-rows-auto place-items-center">
+        {children}
+        <ScrollToTopButton />
+      </div>
     </>
   );
 }

--- a/src/hooks/useInfinite.ts
+++ b/src/hooks/useInfinite.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react"
+
+function useInfinite() {
+  const ref = useRef();
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setIsIntersecting(true);
+        } else {
+          setIsIntersecting(false)
+        }
+      })
+    });
+    if (ref.current) {
+      io.observe(ref.current)
+    }
+
+    return () => {
+      io.disconnect();
+    }
+  }, [ref])
+  
+  return [ref, isIntersecting]
+}
+
+export default useInfinite

--- a/src/hooks/useInfinite.ts
+++ b/src/hooks/useInfinite.ts
@@ -1,4 +1,4 @@
-import { LegacyRef, RefObject, useEffect, useRef, useState } from 'react';
+import { LegacyRef, useEffect, useRef, useState } from 'react';
 
 function useInfinite(): [LegacyRef<HTMLDivElement>, boolean] {
   const ref = useRef<HTMLDivElement>(null);

--- a/src/hooks/useInfinite.ts
+++ b/src/hooks/useInfinite.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 
 function useInfinite() {
-  const ref = useRef();
+  const ref = useRef<HTMLDivElement>();
   const [isIntersecting, setIsIntersecting] = useState(false);
 
   useEffect(() => {

--- a/src/hooks/useInfinite.ts
+++ b/src/hooks/useInfinite.ts
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from "react"
+import { LegacyRef, RefObject, useEffect, useRef, useState } from 'react';
 
-function useInfinite() {
-  const ref = useRef<HTMLDivElement>();
+function useInfinite(): [LegacyRef<HTMLDivElement>, boolean] {
+  const ref = useRef<HTMLDivElement>(null);
   const [isIntersecting, setIsIntersecting] = useState(false);
 
   useEffect(() => {
@@ -10,20 +10,20 @@ function useInfinite() {
         if (entry.isIntersecting) {
           setIsIntersecting(true);
         } else {
-          setIsIntersecting(false)
+          setIsIntersecting(false);
         }
-      })
+      });
     });
     if (ref.current) {
-      io.observe(ref.current)
+      io.observe(ref.current);
     }
 
     return () => {
       io.disconnect();
-    }
-  }, [ref])
-  
-  return [ref, isIntersecting]
+    };
+  }, [ref]);
+
+  return [ref, isIntersecting];
 }
 
-export default useInfinite
+export default useInfinite;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,16 +4,28 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
-
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
+import type { ReactElement, ReactNode } from 'react';
+import type { NextPage } from 'next';
+
 const queryClient = new QueryClient();
 
-export default function App({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <QueryClientProvider client={queryClient}>
       <HydrationBoundary state={pageProps.dehydratedState}>
-        <Component {...pageProps} />
+        {getLayout(<Component {...pageProps} />)}
       </HydrationBoundary>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import type { NextPage } from 'next';
 const queryClient = new QueryClient();
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  // eslint-disable-next-line no-unused-vars
   getLayout?: (page: ReactElement) => ReactNode;
 };
 
@@ -20,7 +21,6 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
-  // eslint-disable-next-line no-unused-vars
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,7 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  // eslint-disable-next-line no-unused-vars
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,11 +6,11 @@ function Home() {
   return (
     //메인페이지 각 컴포넌트 넣을자리에 div로 표시만 해둠
     <>
-      <div className="bg-green h-480 w-[1080px] mt-40 mb-87">A</div>
-      <div className="bg-gray-3 h-482 w-[1200px]">B</div>
-      <div className="bg-green h-[581px] w-[1200px]">C</div>
-      <div className="bg-gray-3 h-[633px] w-[1200px]">D</div>
-      <div className="bg-green h-[800px] w-[1080px] mt-120 ">E</div>
+      <div className="bg-green h-480 w-[1080px] mt-40 mb-87 flex-center">div두개있는 젤 위에꺼</div>
+      <div className="bg-gray-3 h-482 w-[1200px] flex-center">맞춤도서</div>
+      <div className="bg-green h-[581px] w-[1200px] flex-center">신간도서</div>
+      <div className="bg-gray-3 h-[633px] w-[1200px] flex-center">실시간 인기 도서</div>
+      <div className="bg-green h-[800px] w-[1080px] mt-120 flex-center">베스트셀러</div>
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from 'react';
 import MainLayout from '@/components/layout/mainLayout';
-import { NextPageWithLayout } from '@/pages/_app';
 
 function Home() {
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,11 +6,23 @@ function Home() {
   return (
     //메인페이지 각 컴포넌트 넣을자리에 div로 표시만 해둠
     <>
-      <div className="bg-green h-480 w-[1080px] mt-40 mb-87 flex-center">div두개있는 젤 위에꺼</div>
-      <div className="bg-gray-3 h-482 w-[1200px] flex-center">맞춤도서</div>
-      <div className="bg-green h-[581px] w-[1200px] flex-center">신간도서</div>
-      <div className="bg-gray-3 h-[633px] w-[1200px] flex-center">실시간 인기 도서</div>
-      <div className="bg-green h-[800px] w-[1080px] mt-120 flex-center">베스트셀러</div>
+      <div
+        className="bg-green h-480 w-[1080px] mt-40 mb-87 flex-center tablet:w-[688px] tablet:mb-80
+          mobile:w-330 mobile:mb-20">
+        div두개있는 젤 위에꺼
+      </div>
+      <div className="bg-gray-3 h-482 w-[1200px] flex-center tablet:w-full mobile:w-full">
+        맞춤도서
+      </div>
+      <div className="bg-green h-[581px] w-[1200px] flex-center tablet:w-full mobile:w-full">
+        신간도서
+      </div>
+      <div className="bg-gray-3 h-[633px] w-[1200px] flex-center tablet:w-full mobile:w-full">
+        실시간 인기 도서
+      </div>
+      <div className="bg-green h-[800px] w-[1080px] mt-120 flex-center tablet:w-[688px] mobile:w-330">
+        베스트셀러
+      </div>
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,27 +1,22 @@
-import { Inter } from 'next/font/google';
-import { countAtom } from '@/store/count';
-import { useAtom } from 'jotai';
+import { ReactElement } from 'react';
+import MainLayout from '@/components/layout/mainLayout';
+import { NextPageWithLayout } from '@/pages/_app';
 
-const inter = Inter({
-  subsets: ['latin'],
-});
-
-export default function Home() {
-  const [count, setCount] = useAtom(countAtom);
-
-  const handleAddCount = () => {
-    setCount((prev) => prev + 1);
-  };
-  const handleMinusCount = () => {
-    setCount((prev) => prev - 1);
-  };
-
+function Home() {
   return (
-    <main
-      className={`flex min-h-screen flex-col items-center p-24 ${inter.className}`}>
-      <button onClick={handleAddCount}>count++</button>
-      <button onClick={handleMinusCount}>count--</button>
-      {count}
-    </main>
+    //메인페이지 각 컴포넌트 넣을자리에 div로 표시만 해둠
+    <>
+      <div className="bg-green h-480 w-[1080px] mt-40 mb-87">A</div>
+      <div className="bg-gray-3 h-482 w-[1200px]">B</div>
+      <div className="bg-green h-[581px] w-[1200px]">C</div>
+      <div className="bg-gray-3 h-[633px] w-[1200px]">D</div>
+      <div className="bg-green h-[800px] w-[1080px] mt-120 ">E</div>
+    </>
   );
 }
+
+Home.getLayout = function getLayout(page: ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
+};
+
+export default Home;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,3 +1,5 @@
 import { atom } from "jotai";
 
 export const countAtom = atom(0);
+
+export const headerVisibleAtom = atom(true);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,7 +25,7 @@ const config: Config = {
   ],
   theme: {
     screens: {
-      mobile: { min: '375px', max: '767px' },
+      mobile: { min: '360px', max: '767px' },
       tablet: { min: '768px', max: '1199px' },
       pc: '1200px',
     },


### PR DESCRIPTION
## 구현사항
- [x] mainPage Layout 구현했어요
- [x] header navbar가 안보일때 ScrollToUp버튼이 나타나요
## 사용방법
- 'layout/MainLayout'에 있는 div는 각 컴포넌트가 들어갈 자리라서 div로 표현만 해놨어요
![스크린샷 2024-01-26 오후 10 58 09(2)](https://github.com/bookstore-README/front_bookstore-README/assets/138510303/f19513d3-40f3-40a3-b071-57f89338cc09)

## 스크린샷
- scrollToUpButton
![2024-01-2611 04 04-ezgif com-video-to-gif-converter](https://github.com/bookstore-README/front_bookstore-README/assets/138510303/1c827a93-7251-4011-a123-f97d3611974e)


##### close #34
