### PR TITLE
[#62]  책 미리보기 컴포넌트 라벨색변경 기능+가격표시 추가 

### DIFF
--- a/src/components/book/previewBookInfo/previewBookInfo.tsx
+++ b/src/components/book/previewBookInfo/previewBookInfo.tsx
@@ -6,7 +6,7 @@ import { THOUSAND_UNIT } from 'src/constants/price';
 const BookLabelIcon = ({ fill ='#66C57B'}) => (
    <svg width="26" height="34" viewBox="0 0 26 34" fill="cover" xmlns="http://www.w3.org/2000/svg">
     <path id="Vector" d="M26 34L13 24.5556L0 34V3.77778C0 2.77585 0.391325 1.81496 1.08789 1.10649C1.78445 0.398015 2.7292 0 3.71429 0H22.2857C23.2708 0 24.2155 0.398015 24.9121 1.10649C25.6087 1.81496 26 2.77585 26 3.77778V34Z" fill={fill} />
-</svg>
+  </svg>
 );
 
 interface PreviewBookInfoProps {
@@ -100,7 +100,7 @@ function PreviewBookInfo({
                 <span
                   className={`text-white text-13 font-bold absolute top-0 left-10 ${
                     ranking > 9 && 'tracking-[-0.5px] left-5' 
-                  } ${ranking > 99 && 'tracking-[-0.5px] left-0'}`}>
+                  } ${ranking > 99 && 'tracking-[-0.5px] left-[-1px]'}`}>
                   {ranking}
                 </span>
               </div>

--- a/src/components/book/previewBookInfo/previewBookInfo.tsx
+++ b/src/components/book/previewBookInfo/previewBookInfo.tsx
@@ -1,8 +1,13 @@
 import Image, { StaticImageData } from 'next/image';
 import DefaultImage from '@/public/images/SampleBookCover4.jpeg';
-import BookLabel from '@/public/icons/BookLabelIcon.svg';
 import { useRef, useState } from 'react';
 import { THOUSAND_UNIT } from 'src/constants/price';
+
+const BookLabelIcon = ({ fill ='#66C57B'}) => (
+   <svg width="26" height="34" viewBox="0 0 26 34" fill="cover" xmlns="http://www.w3.org/2000/svg">
+    <path id="Vector" d="M26 34L13 24.5556L0 34V3.77778C0 2.77585 0.391325 1.81496 1.08789 1.10649C1.78445 0.398015 2.7292 0 3.71429 0H22.2857C23.2708 0 24.2155 0.398015 24.9121 1.10649C25.6087 1.81496 26 2.77585 26 3.77778V34Z" fill={fill} />
+</svg>
+);
 
 interface PreviewBookInfoProps {
   image?: string | StaticImageData; // TODO: 테스트 후 수정하기(string타입 필요없을지도?)
@@ -62,7 +67,7 @@ function PreviewBookInfo({
 
   const handleImageLoaded = () => {
     setImageLoaded(true);
-    if ((bookImageRef.current?.height || 0) > imageSize.heightNumber, isLabelMove) {
+    if ((bookImageRef.current?.height || 0) > imageSize.heightNumber && isLabelMove) {
       setIsLabelMove(true);
     }
   };
@@ -88,20 +93,14 @@ function PreviewBookInfo({
               ref={bookImageRef}
               onLoad={handleImageLoaded}
             />
-
             {ranking && (
               <div
                 className={`absolute left-17 ${isLabelMove && size !== 'lg' ? 'top-[-3px]' : 'top-[-2px]'}`}>
-                <Image
-                  src={BookLabel}
-                  alt="베스트셀러 라벨 아이콘"
-                  width={26}
-                  height={34}
-                />
+                <BookLabelIcon fill={ranking > 10 ? '#ABABAB' : undefined } />
                 <span
                   className={`text-white text-13 font-bold absolute top-0 left-10 ${
-                    ranking > 9 && 'tracking-[-0.5px] left-5'
-                  }`}>
+                    ranking > 9 && 'tracking-[-0.5px] left-5' 
+                  } ${ranking > 99 && 'tracking-[-0.5px] left-0'}`}>
                   {ranking}
                 </span>
               </div>

--- a/src/components/book/previewBookInfo/previewBookInfo.tsx
+++ b/src/components/book/previewBookInfo/previewBookInfo.tsx
@@ -2,6 +2,7 @@ import Image, { StaticImageData } from 'next/image';
 import DefaultImage from '@/public/images/SampleBookCover4.jpeg';
 import BookLabel from '@/public/icons/BookLabelIcon.svg';
 import { useRef, useState } from 'react';
+import { THOUSAND_UNIT } from 'src/constants/price';
 
 interface PreviewBookInfoProps {
   image?: string | StaticImageData; // TODO: 테스트 후 수정하기(string타입 필요없을지도?)
@@ -10,6 +11,8 @@ interface PreviewBookInfoProps {
   authorList?: string[];
   ranking?: number;
   size: 'sm' | 'md' | 'lg';
+  price?: number;
+  category?: string;
 }
 
 function PreviewBookInfo({
@@ -19,6 +22,8 @@ function PreviewBookInfo({
   ranking,
   alignCenter,
   size = 'md',
+  price,
+  category,
 }: PreviewBookInfoProps) {
   const bookImageRef = useRef<HTMLImageElement>(null);
   const [isLabelMove, setIsLabelMove] = useState(false);
@@ -113,8 +118,18 @@ function PreviewBookInfo({
         </p>
       )}
       {authorList && (
-        <div className="text-gray-3 text-14 hover:text-gray-7 truncate">
+        <div className="text-gray-3 text-14 truncate">
           {authorList.join(', ')}
+        </div>
+      )}
+      {category && (
+        <div className="text-gray-3 text-14 ">
+          [{category}]
+        </div>
+      )}
+       {price && (
+        <div className="text-black text-14 font-bold mt-4">
+          {price.toString().replace(THOUSAND_UNIT,",")}
         </div>
       )}
     </div>

--- a/src/constants/price.ts
+++ b/src/constants/price.ts
@@ -1,0 +1,2 @@
+// 천 단위 마다 콤마 찍어주는 정규식
+export const THOUSAND_UNIT = /\B(?=(\d{3})+(?!\d))/g;

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -11,23 +11,22 @@ function TestPage() {
         authorList={['이승연', '작가얌', '작가2', '작가3', '작가3', '작가3']}
         size="lg"
         ranking={10}
-        // image={TestImage}
+        category="가정/육아"
+        price={123456789}
       />
       <PreviewBookInfo
         title="어머 이책 사야해!"
         authorList={['이승연', '작가얌', '작가2', '작가333']}
         size="md"
-        ranking={10}
+        ranking={30}
         image={TestImage2}
       />
       <PreviewBookInfo
         title="겁나 비싼 책"
         authorList={['이승연', '작가얌', '작가2', '작가3']}
         size="sm"
-        ranking={10}
+        ranking={100}
         image={TestImage1}
-        category="가정/육아"
-        price={123456789}
       />
     </div>
   );

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -4,19 +4,6 @@ import TestImage1 from '@/public/images/SampleBookCover1.jpeg';
 import TestImage2 from '@/public/images/SampleBookCover3.jpeg';
 
 function TestPage() {
-  // const person1 = {
-  //   id: 1,
-  //   name: 'yuna',
-  //   isPurchased: true,
-  //   firstPurchasedDate: '2019.12.12',
-  // };
-  // const person2 = {
-  //   id: 2,
-  //   name: 'yuna2',
-  //   isPurchased: false,
-  //   firstPurchasedDate: null,
-  // };
-
   return (
     <div className="flex flex-col gap-20 p-20">
       <PreviewBookInfo
@@ -34,11 +21,13 @@ function TestPage() {
         image={TestImage2}
       />
       <PreviewBookInfo
-        title="어머 이책 사야해!"
+        title="겁나 비싼 책"
         authorList={['이승연', '작가얌', '작가2', '작가3']}
         size="sm"
         ranking={10}
         image={TestImage1}
+        category="가정/육아"
+        price={123456789}
       />
     </div>
   );


### PR DESCRIPTION
## 구현사항

- [x] 가격 표시 (천 단위)
- [x] 11위부터 순위라벨 회색표시
- [x] 100위(세자리 수) 숫자 위치 조정

## 사용방법
price와 category 옵셔널 프롭스가 추가되었습니다.
![스크린샷 2024-01-30 오후 4 17 41](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/6aac8a84-97d7-43b6-b159-c5c08a8620f5)

## 스크린샷
- 카테고리 및 가격 표시
<img width="224" alt="스크린샷 2024-01-30 오후 4 21 33" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/ef1ee683-6be0-4d58-bc3d-61e9a3afb588">
<br>

- 11위 이상 표시
<img width="224" alt="스크린샷 2024-01-30 오후 4 21 49" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/88eb4bf4-dc80-4ac4-b14b-468362c8ad5e">
<br>

-100위 (세자리) 표시
<img width="224" alt="스크린샷 2024-01-30 오후 4 21 57" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/a4ae6ee4-2501-4d6f-90a9-dc1c9ffcfe5e">



##### close #62 
