### PR TITLE
[#71] scroll to up ref 수정

### DIFF
--- a/src/components/button/scrollToTopButton.tsx
+++ b/src/components/button/scrollToTopButton.tsx
@@ -1,10 +1,10 @@
 import ScrollToTopButtonImg from '@/public/icons/ScrollToTopButton.svg';
-import { headerVisibleAtom } from '@/store/state';
+import { pointVisibleAtom } from '@/store/state';
 import { useAtom } from 'jotai';
 import Image from 'next/image';
 
 function ScrollToTopButton() {
-  const [headerVisible] = useAtom(headerVisibleAtom);
+  const [headerVisible] = useAtom(pointVisibleAtom);
 
   const handleClickScrollToTop = () => {
     if (!headerVisible) {

--- a/src/components/layout/headerLayout.tsx
+++ b/src/components/layout/headerLayout.tsx
@@ -1,17 +1,9 @@
 import Navigation from '@/components/header/navigation';
-import useInfinite from '@/hooks/useInfinite';
-import { headerVisibleAtom } from '@/store/state';
-import { useAtom } from 'jotai';
 import { ReactElement } from 'react';
 
 function HeaderLayout({ children }: { children: ReactElement }) {
-  const [ref, isIntersecting] = useInfinite();
-  const [, setHeaderVisible] = useAtom(headerVisibleAtom);
-
-  setHeaderVisible(isIntersecting);
-
   return (
-    <div className="flex-row h-90 tablet:h-170 pc:h-170" ref={ref}>
+    <div className="flex-row h-90 tablet:h-170 pc:h-170">
       {children} <Navigation />
     </div>
   );

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -1,16 +1,25 @@
 import Header from '@/components/header/index';
 import { ReactNode } from 'react';
 import ScrollToTopButton from '@/components/button/scrollToTopButton';
+import useInfinite from '@/hooks/useInfinite';
+import { useAtom } from 'jotai';
+import { headerVisibleAtom } from '@/store/state';
 
 interface MainLayoutProps {
   children: ReactNode;
 }
 
 function MainLayout({ children }: MainLayoutProps) {
+  const [ref, isIntersecting] = useInfinite();
+  const [, setHeaderVisible] = useAtom(headerVisibleAtom);
+
+  setHeaderVisible(isIntersecting);
+
   return (
     <>
       <Header isLoggedIn={true} numItemsOfCart={1} />
       <div className="relative grid auto-rows-auto place-items-center tablet:max-w-[768px]">
+        <div className="w-300 h-20" ref={ref}/>
         {children}
         <ScrollToTopButton />
       </div>

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import ScrollToTopButton from '@/components/button/scrollToTopButton';
 import useInfinite from '@/hooks/useInfinite';
 import { useAtom } from 'jotai';
-import { headerVisibleAtom } from '@/store/state';
+import { pointVisibleAtom } from '@/store/state';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -11,9 +11,9 @@ interface MainLayoutProps {
 
 function MainLayout({ children }: MainLayoutProps) {
   const [ref, isIntersecting] = useInfinite();
-  const [, setHeaderVisible] = useAtom(headerVisibleAtom);
+  const [, setPointVisible] = useAtom(pointVisibleAtom);
 
-  setHeaderVisible(isIntersecting);
+  setPointVisible(isIntersecting);
 
   return (
     <>

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -2,4 +2,4 @@ import { atom } from "jotai";
 
 export const countAtom = atom(0);
 
-export const headerVisibleAtom = atom(true);
+export const pointVisibleAtom = atom(true);


### PR DESCRIPTION
## 구현사항
- [x] header sticky로 변경되면서 ScrollToUp button이 나타나는 기준이 header에서 새로운 div로 변경이 불가피했음
- [x] mainPage container에 div를 만들어서 그 부분이 안보일때 button이 나타나도록 변경함. 

## 사용방법
- [x] #34

## 스크린샷

https://github.com/bookstore-README/front_bookstore-README/assets/138510303/00ebc53f-e280-41c1-a8ec-4474fd3fc671

##### close #71
