### PR TITLE
[#153] 선호장르 선택 섹션 구현

### DIFF
--- a/src/components/container/genreSection/genreSection.tsx
+++ b/src/components/container/genreSection/genreSection.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import GenreButton from '@/components/button/genre/genreButton';
+import { ReadMeGenreList } from '@/pages/api/mock';
+import EditToggleButton from '@/components/button/editToggleButton';
+
+function GenreSection() {
+  const [isEditMode, setEditMode] = useState(false);
+  const genres = ReadMeGenreList.genreList;
+
+  const handleEditModeToggle = () => {
+    setEditMode((prev) => !prev);
+  };
+
+  const getButtonLayoutClass = () => {
+    return 'flex-center flex-wrap pc:w-[1028px] tablet:w-[688px] mobile:w-331 gap-4';
+  };
+
+  return (
+    <div className="flex-center mt-40 flex-col">
+      <div className="mb-28 text-20 font-bold">선호장르 선택</div>
+
+      <div className={`${getButtonLayoutClass()}`}>
+        {genres.map((genre, index) => (
+          <GenreButton
+            key={index}
+            title={genre.title}
+            selected={genre.selected}
+            editMode={isEditMode}
+          />
+        ))}
+      </div>
+      <div className="mx-60 ml-auto mt-80">
+        <EditToggleButton
+          isEditMode={isEditMode}
+          onClick={handleEditModeToggle}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default GenreSection;


### PR DESCRIPTION
## 구현사항
이미 올렸다 생각했는데 안 올렸더군요.. 늦게나마 올립니다.
- [x] 수정하기 버튼을 클릭했을 때만 선호장르 버튼 선택 가능, 보더 초록색
- [x] 적용완료 시 선택된 버튼의 보더는 검은색

## 사용방법
<GenreSection/>

## 스크린샷
<img width="1164" alt="스크린샷 2024-02-07 오전 1 31 42" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/d82740fc-2385-4c49-ab0d-2f05d606cb8e">


##### close #153
