### PR TITLE
[#177] 설정 페이지-선호장르 선택 조립

### DIFF
--- a/src/components/container/genreSection/genreSection.tsx
+++ b/src/components/container/genreSection/genreSection.tsx
@@ -15,7 +15,7 @@ function GenreSection() {
     if (isEditMode) {
       notify({
         type: 'success',
-        text: '선호장를 변경했어요 📙',
+        text: '선호장를 변경했어요 ⭐️',
       });
     }
   };

--- a/src/components/container/genreSection/genreSection.tsx
+++ b/src/components/container/genreSection/genreSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import GenreButton from '@/components/button/genre/genreButton';
 import { ReadMeGenreList } from '@/pages/api/mock';
 import EditToggleButton from '@/components/button/editToggleButton';
+import { notify } from '@/components/toast/toast';
 
 function GenreSection() {
   const [isEditMode, setEditMode] = useState(false);
@@ -9,6 +10,14 @@ function GenreSection() {
 
   const handleEditModeToggle = () => {
     setEditMode((prev) => !prev);
+    // 성공시 토스트 메시지 띄우기
+    // TODO: isEditMode 조건을 api 연결 성공시로 변경
+    if (isEditMode) {
+      notify({
+        type: 'success',
+        text: '선호장를 변경했어요 📙',
+      });
+    }
   };
 
   const getButtonLayoutClass = () => {
@@ -16,7 +25,7 @@ function GenreSection() {
   };
 
   return (
-    <div className="flex-center mt-40 flex-col">
+    <div className="flex-center flex-col">
       <div className="mb-28 text-20 font-bold">선호장르 선택</div>
 
       <div className={`${getButtonLayoutClass()}`}>

--- a/src/components/layout/settingPageLayout.tsx
+++ b/src/components/layout/settingPageLayout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface SettingPageLayoutProps {
+  header: ReactNode;
+  main: ReactNode;
+}
+
+function SettingPageLayout({ header, main }: SettingPageLayoutProps) {
+  return (
+    <>
+      <div role="container" className="flex flex-col gap-40">
+        <div role="header">{header}</div>
+        <div role="content" className="flex-center">
+          {main}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default SettingPageLayout;

--- a/src/pages/mypage/setting/selectGenre/index.tsx
+++ b/src/pages/mypage/setting/selectGenre/index.tsx
@@ -1,5 +1,9 @@
-import MainLayout from "@/components/layout/mainLayout";
+import SettingPageLayout from '@/components/layout/settingPageLayout';
+import Header from '@/components/header';
+import GenreSection from '@/components/container/genreSection/genreSection';
 
-export default function SelectGenre() {
-  return <MainLayout>장르 선택</MainLayout>;
+export default function EditProfilePage() {
+  return (
+    <SettingPageLayout header={<Header isLoggedIn />} main={<GenreSection />} />
+  );
 }

--- a/src/pages/mypage/setting/selectGenre/index.tsx
+++ b/src/pages/mypage/setting/selectGenre/index.tsx
@@ -2,7 +2,7 @@ import SettingPageLayout from '@/components/layout/settingPageLayout';
 import Header from '@/components/header';
 import GenreSection from '@/components/container/genreSection/genreSection';
 
-export default function EditProfilePage() {
+export default function SelectGenrePage() {
   return (
     <SettingPageLayout header={<Header isLoggedIn />} main={<GenreSection />} />
   );


### PR DESCRIPTION
## 구현사항

- GenreSection 컴포넌트를 'mypage/setting/selectGenre' 페이지에 조립했어요
- 장르 변경 완료시 토스트 메시지를 띄워요


## 사용방법
![스크린샷 2024-02-09 오후 1 58 38](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/22245a13-c72d-49fd-9ab3-d88161ddfcaf)


## 스크린샷


https://github.com/bookstore-README/front_bookstore-README/assets/120437902/35ce83b6-fe95-4c42-8335-10af6e664743


- 토스트 메시지가 중간에 멈춘건 개발자도구 상태라 딴데 클릭해서 그래용ㅎ...


##### close #177 
