### PR TITLE
[#161] 카테고리 사이드바 api 연결 및 전역 상태관리 >> 서버 문제로 임시 close

### DIFF
--- a/src/api/category.ts
+++ b/src/api/category.ts
@@ -6,3 +6,8 @@ export const getCategory = async (category:string) => {
   return result.data;
 };
 
+// 전체 카테고리 리스트 조회
+export const getCategoryList = async () => {
+  const result = await instance.get(`/category`);
+  return result.data.data;
+};

--- a/src/components/button/sidebar/sidebarRegionButton.tsx
+++ b/src/components/button/sidebar/sidebarRegionButton.tsx
@@ -1,7 +1,11 @@
 /* 카테고리 페이지의 사이드바 '국내 외국' 선택 버튼 */
 
-import { SidebarProps } from '@/types/sidebarType';
 import Link from 'next/link';
+import { useAtom } from 'jotai';
+
+import useSetLocatedCategory from '@/hooks/useSetLocatedCategory';
+import { SidebarProps } from '@/types/sidebarType';
+import { LocatedCategoryAtom } from '@/store/state';
 
 function classNames<T>(...classes: Array<T>) {
   return classes.filter(Boolean).join(' ');
@@ -24,28 +28,37 @@ function StyledLink({
       : 'pl-12 mobile:rounded-r-lg -left-1',
   );
 
+  const { updateLocatedCategory } = useSetLocatedCategory();
+
   return (
-    <Link className={SidebarLinkClassNames} href={link}>
+    <Link
+      onClick={() => {
+        let main = title === "국내" ? 0 : 1;
+        updateLocatedCategory(main);
+      }}
+      className={SidebarLinkClassNames} href={link}>
       {title}
     </Link>
   );
 }
 
-function SidebarRegionButton({ pageName, isDomestic = true }: SidebarProps) {
+function SidebarRegionButton({ pageName }: SidebarProps) {
+  const [locatedCategory] = useAtom(LocatedCategoryAtom);
+  
   return (
     <div className="mobile:flex-center flex items-center justify-start">
       <StyledLink
         title="국내"
         link={`/domestic/${pageName ?? ''}`}
         isLeft={true}
-        isSelected={isDomestic}
+        isSelected={locatedCategory.mainId === 0}
       />
       <div className="relative z-10 h-11 w-[1px] bg-gray-1 mobile:h-37 mobile:bg-green"></div>
       <StyledLink
         title="외국"
         link={`/foreign/${pageName ?? ''}`}
         isLeft={false}
-        isSelected={!isDomestic}
+        isSelected={locatedCategory.mainId === 1}
       />
     </div>
   );

--- a/src/components/button/sidebar/sidebarTab.tsx
+++ b/src/components/button/sidebar/sidebarTab.tsx
@@ -1,35 +1,44 @@
 import Link from 'next/link';
-import {
-  ReadMeForeignCategoryList,
-  ReadMeDomesticCategoryList,
-} from '@/pages/api/mock';
+import { useAtom } from 'jotai';
+
+import { CategoryListAtom, LocatedCategoryAtom } from '@/store/state';
+import useSetLocatedCategory from '@/hooks/useSetLocatedCategory';
 import { SidebarProps } from '@/types/sidebarType';
 
-function SidebarTab({ pageName, isDomestic, location }: SidebarProps) {
-  const categoryList = isDomestic
-    ? ReadMeDomesticCategoryList.categoryList
-    : ReadMeForeignCategoryList.categoryList;
+function SidebarTab({ pageName}: SidebarProps) {
+  const [categoryList,] = useAtom(CategoryListAtom);
+  const [locatedCategory] = useAtom(LocatedCategoryAtom);
+  const { updateLocatedCategory } = useSetLocatedCategory();
+
   return (
     <div
       className="absolute z-20 flex flex-col gap-12 bg-white pt-20
         mobile:right-0 mobile:top-65 mobile:h-[468px] mobile:w-270
         mobile:flex-wrap mobile:gap-5 mobile:rounded-[10px] mobile:border-[1px] mobile:border-gray-1 mobile:p-15">
       <Link
-        className={`block text-[13px] ${location ? 'text-gray-2' : 'font-bold text-green'}`}
-        href={`/${isDomestic ? 'domestic' : 'foreign'}`}>
+        onClick={() => {
+          updateLocatedCategory(locatedCategory.mainId);
+        }}
+        className={`block text-[13px] ${locatedCategory.subId ? 'text-gray-2' : 'font-bold text-green'}`}
+        href={`/${locatedCategory.mainId === 0 ? 'domestic' : 'foreign'}`}>
         전체보기
       </Link>
-      {categoryList.map((el) => {
+      {(categoryList) && categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"].map((el, ind) => {
         return (
           <Link
-            className={`block text-[13px] ${
-              el.link === `/${location}`
-                ? 'font-bold text-green'
-                : 'text-gray-2'
-            }`}
-            href={`/${isDomestic ? 'domestic' : 'foreign'}${el.link}${pageName ? `/${pageName}` : ''}`}
-            key={el.title}>
-            {el.title}
+              onClick={() => {
+                let main = el.mainId;
+                let sub = el.subId
+                updateLocatedCategory(main, sub);
+              }}
+              className={`block text-[13px] ${
+                (el.mainId, el.subId) === (locatedCategory.mainId, locatedCategory.subId)
+                  ? 'font-bold text-green'
+                  : 'text-gray-2'
+              }`}
+              href={`/${locatedCategory.mainId === 0 ? 'domestic' : 'foreign'}${el.link}${pageName ? `/${pageName}` : ''}`}
+              key={el?.categoryId}>
+            {el?.subName}
           </Link>
         );
       })}

--- a/src/components/button/sidebar/sidebarTabController.tsx
+++ b/src/components/button/sidebar/sidebarTabController.tsx
@@ -7,31 +7,22 @@
  */
 
 import Image from 'next/image';
+import { useAtom } from 'jotai';
 import { useRef } from 'react';
 
 import SidebarTab from '@/components/button/sidebar/sidebarTab';
 import useShowDropDown from '@/hooks/useShowDropDown';
 import useCarouselEnv from '@/hooks/useCarouselEnv';
-import {
-  ReadMeDomesticCategoryList,
-  ReadMeForeignCategoryList,
-} from '@/pages/api/mock';
 import { SidebarProps } from '@/types/sidebarType';
+import { CategoryListAtom, LocatedCategoryAtom } from '@/store/state';
 
-function SidebarTabController({
-  pageName,
-  isDomestic,
-  location,
-}: SidebarProps) {
+function SidebarTabController({pageName}: SidebarProps) {
   const ref = useRef(null);
   const [showOptions, setShowOptions] = useShowDropDown(ref, false);
   const { env } = useCarouselEnv();
-  const categoryList = isDomestic
-    ? ReadMeDomesticCategoryList.categoryList
-    : ReadMeForeignCategoryList.categoryList;
-
-  const found = categoryList.find((e) => e.link === `/${location}`);
-  const locatedTitle = location ? found?.title : '전체보기';
+  const [categoryList,] = useAtom(CategoryListAtom);
+  const [locatedCategory] = useAtom(LocatedCategoryAtom);
+  const locatedTitle = locatedCategory.subId ? categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"][locatedCategory.subId].subName : '전체보기';
 
   const handleClick = () => setShowOptions(!showOptions);
 
@@ -54,8 +45,6 @@ function SidebarTabController({
       {(showOptions || env !== 'mobile') && (
         <SidebarTab
           pageName={pageName}
-          isDomestic={isDomestic}
-          location={location}
         />
       )}
     </>

--- a/src/components/header/navigationTab.tsx
+++ b/src/components/header/navigationTab.tsx
@@ -6,6 +6,9 @@ import Link from 'next/link';
 import WritePostButton from '@/components/button/header/writePostButton';
 import AddCommunityCard from '@/components/modal/addCommunityCard';
 import CustomBookButton from '@/components/button/header/customBookButton';
+import useSetLocatedCategory from '@/hooks/useSetLocatedCategory';
+import { useAtom } from 'jotai';
+import { LocatedCategoryAtom } from '@/store/state';
 
 interface NavigationTabProps {
   isLoggedIn: boolean;
@@ -16,6 +19,8 @@ function NavigationTab({ isLoggedIn }: NavigationTabProps) {
   const router = useRouter();
   // 현재 페이지 경로 확인
   const currentPath = router.pathname;
+    const [locatedCategory] = useAtom(LocatedCategoryAtom);
+  const { updateLocatedCategory } = useSetLocatedCategory();
 
   // 특정 페이지에서만 WritePostButton을 보이도록 조건을 설정
   const showWritePostButton =
@@ -30,6 +35,10 @@ function NavigationTab({ isLoggedIn }: NavigationTabProps) {
     setIsModalOpen(!isModalOpen);
   };
 
+  const resetLocatedCategory = () => {
+    updateLocatedCategory(locatedCategory.mainId);
+  }
+
   return (
     <>
       <div
@@ -40,8 +49,8 @@ function NavigationTab({ isLoggedIn }: NavigationTabProps) {
             <CategoryTabButton onClick={toggleCategoryTab} />
           </div>
           <div className="flex gap-18 pc:gap-40 tablet:gap-30">
-            <Link href="/domestic/bestseller"> 베스트</Link>
-            <Link href="/domestic/newest"> 신간</Link>
+            <Link onClick={resetLocatedCategory} href="/domestic/bestseller"> 베스트</Link>
+            <Link onClick={resetLocatedCategory} href="/domestic/newest"> 신간</Link>
             <CustomBookButton isLoggedIn={isLoggedIn} />
             <div className="inline-block border-r w-1 h-14 mt-4 border-gray-1" />
 

--- a/src/components/layout/sidebarLayout.tsx
+++ b/src/components/layout/sidebarLayout.tsx
@@ -1,7 +1,4 @@
-/** 카테고리 페이지
- * @param isDomestic: required, 불린형, 현재 페이지가 domestic인지 아닌지 판별하는 인자값
- * @param location: optional, 불린형, 현재 페이지가 domestic/하위 페이지 중 어디에 있는지 체크. 없다면 전체보기 페이지에 있다는 것으로 간주, "healthhobby" 이런 식으로 하위페이지 id 값이 들어옴.
- */
+/** 카테고리 페이지 */
 
 import { ReactNode } from 'react';
 
@@ -15,8 +12,6 @@ interface SidebarLayoutProps extends SidebarProps {
 
 function SidebarLayout({
   pageName,
-  isDomestic,
-  location,
   children,
 }: SidebarLayoutProps) {
   return (
@@ -33,8 +28,6 @@ function SidebarLayout({
               mobile:h-35 mobile:w-full">
             <Sidebar
               pageName={pageName}
-              isDomestic={isDomestic}
-              location={location}
             />
           </aside>
           <div>{children}</div>

--- a/src/components/list/categoryBookList/categoryBookList.tsx
+++ b/src/components/list/categoryBookList/categoryBookList.tsx
@@ -13,7 +13,7 @@ interface CategoryBookList {
   subCategory?: string;
 }
 
-function CategoryBookList({ mainCategory, subCategory }: CategoryBookList) {
+function CategoryBookList() {
   const [selectedOrder, setSelectedOrder] = useState("조회순");
   const onSelectedOrder = (menu: string) => {
     setSelectedOrder(menu);

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -2,14 +2,12 @@ import SidebarTabController from '@/components/button/sidebar/sidebarTabControll
 import SidebarRegionButton from '@/components/button/sidebar/sidebarRegionButton';
 import { SidebarProps } from '@/types/sidebarType';
 
-function Sidebar({ pageName, isDomestic = true, location }: SidebarProps) {
+function Sidebar({ pageName}: SidebarProps) {
   return (
     <aside className="mobile:flex mobile:justify-between">
-      <SidebarRegionButton pageName={pageName} isDomestic={isDomestic} />
+      <SidebarRegionButton pageName={pageName} />
       <SidebarTabController
         pageName={pageName}
-        isDomestic={isDomestic}
-        location={location}
       />
     </aside>
   );

--- a/src/hooks/useSetLocatedCategory.ts
+++ b/src/hooks/useSetLocatedCategory.ts
@@ -1,0 +1,17 @@
+/** 현재 위치한 카테고리 값을 전역변수로 업데이트하는 훅*/
+
+import { useAtom } from "jotai"
+
+import { LocatedCategoryAtom } from "@/store/state"
+
+function useSetLocatedCategory() {
+  const [, setLocatedCategory] = useAtom(LocatedCategoryAtom);
+  const updateLocatedCategory = (mainId: number, subId?:number) => {
+    setLocatedCategory(() => {
+      return { mainId: mainId, subId: subId };
+    })
+  }
+  return { updateLocatedCategory };
+}
+
+export default useSetLocatedCategory

--- a/src/pages/domestic/[category]/bestseller/index.tsx
+++ b/src/pages/domestic/[category]/bestseller/index.tsx
@@ -3,16 +3,8 @@ import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import Sidebar from '@/components/sidebar/sidebar';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 
-export interface BestSellerPageProps {
-  isDomestic: boolean;
-  category?: string;
-}
-
-function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
+function BestSellerPage() {
   return (
     <div>
       <BestSellerPageLayout
@@ -20,8 +12,6 @@ function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="bestseller"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import SidebarLayout from '@/components/layout/sidebarLayout';
 import Spacing from '@/components/container/spacing/spacing';
 import EventSection from '@/components/container/eventSection/eventSection';
@@ -8,11 +7,8 @@ import { responsive } from '@/utils/checkResponsiveEnv';
 import CategoryBookList from '@/components/list/categoryBookList/categoryBookList';
 
 function CategoryPage() {
-  const router = useRouter();
-  const { category } = router.query;
-
   return (
-      <SidebarLayout isDomestic={true} location={category as string}>
+      <SidebarLayout >
         <Spacing height={[0, 0, 20]} />
 
         <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
@@ -30,7 +26,7 @@ function CategoryPage() {
         </article>        
         <Spacing height={[120, 80, 80]} />
 
-      <CategoryBookList mainCategory="domestic" subCategory={category as string} />
+      <CategoryBookList />
       </SidebarLayout>
   );
 }

--- a/src/pages/domestic/[category]/newest/index.tsx
+++ b/src/pages/domestic/[category]/newest/index.tsx
@@ -2,14 +2,9 @@ import BookOverViewCardList from '@/components/card/bookOverviewCard/bookOverVie
 import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 import Sidebar from '@/components/sidebar/sidebar';
-import { BestSellerPageProps } from '@/pages/domestic/bestseller';
 
-function NewestPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
-
+function NewestPage() {
   return (
     <div>
       <BestSellerPageLayout
@@ -17,8 +12,6 @@ function NewestPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="newest"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/domestic/bestseller/index.tsx
+++ b/src/pages/domestic/bestseller/index.tsx
@@ -3,16 +3,8 @@ import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import Sidebar from '@/components/sidebar/sidebar';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 
-export interface BestSellerPageProps {
-  isDomestic: boolean;
-  category?: string;
-}
-
-function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
+function BestSellerPage() {
   return (
     <div>
       <BestSellerPageLayout
@@ -20,8 +12,6 @@ function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="bestseller"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/domestic/index.tsx
+++ b/src/pages/domestic/index.tsx
@@ -12,7 +12,7 @@ import { carouselMockData } from '../api/mock/carouselMock';
 
 export default function DomesticPage() {
   return (
-      <SidebarLayout isDomestic={true}>
+      <SidebarLayout>
         <Spacing height={[0, 0, 20]} />
 
         <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
@@ -30,7 +30,7 @@ export default function DomesticPage() {
         </article>        
         <Spacing height={[120, 80, 80]} />
 
-        <CategoryBookList mainCategory="domestic"/>
+        <CategoryBookList />
       </SidebarLayout>
   );
 }

--- a/src/pages/domestic/newest/index.tsx
+++ b/src/pages/domestic/newest/index.tsx
@@ -2,14 +2,9 @@ import BookOverViewCardList from '@/components/card/bookOverviewCard/bookOverVie
 import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 import Sidebar from '@/components/sidebar/sidebar';
-import { BestSellerPageProps } from '@/pages/domestic/bestseller';
 
-function NewestPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
-
+function NewestPage() {
   return (
     <div>
       <BestSellerPageLayout
@@ -17,8 +12,6 @@ function NewestPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="newest"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/foreign/[category]/bestseller/index.tsx
+++ b/src/pages/foreign/[category]/bestseller/index.tsx
@@ -3,16 +3,8 @@ import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import Sidebar from '@/components/sidebar/sidebar';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 
-export interface BestSellerPageProps {
-  isDomestic: boolean;
-  category?: string;
-}
-
-function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
+function BestSellerPage( ) {
   return (
     <div>
       <BestSellerPageLayout
@@ -20,8 +12,6 @@ function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="bestseller"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import SidebarLayout from '@/components/layout/sidebarLayout';
 import Spacing from '@/components/container/spacing/spacing';
 import EventSection from '@/components/container/eventSection/eventSection';
@@ -8,11 +7,8 @@ import { responsive } from '@/utils/checkResponsiveEnv';
 import CategoryBookList from '@/components/list/categoryBookList/categoryBookList';
 
 function CategoryPage() {
-  const router = useRouter();
-  const { category } = router.query;
-
   return (
-      <SidebarLayout isDomestic={false} location={category as string}>
+      <SidebarLayout >
         <Spacing height={[0, 0, 20]} />
 
         <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
@@ -30,7 +26,7 @@ function CategoryPage() {
         </article>        
         <Spacing height={[120, 80, 80]} />
 
-      <CategoryBookList mainCategory="foreign" subCategory={category as string} />
+      <CategoryBookList />
       </SidebarLayout>
   );
 }

--- a/src/pages/foreign/[category]/newest/index.tsx
+++ b/src/pages/foreign/[category]/newest/index.tsx
@@ -2,13 +2,9 @@ import BookOverViewCardList from '@/components/card/bookOverviewCard/bookOverVie
 import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 import Sidebar from '@/components/sidebar/sidebar';
-import { BestSellerPageProps } from '@/pages/domestic/bestseller';
 
-function NewestPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
+function NewestPage() {
 
   return (
     <div>
@@ -17,8 +13,6 @@ function NewestPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="newest"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/foreign/bestseller/index.tsx
+++ b/src/pages/foreign/bestseller/index.tsx
@@ -3,16 +3,8 @@ import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import Sidebar from '@/components/sidebar/sidebar';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 
-export interface BestSellerPageProps {
-  isDomestic: boolean;
-  category?: string;
-}
-
-function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
+function BestSellerPage( ) {
   return (
     <div>
       <BestSellerPageLayout
@@ -20,8 +12,6 @@ function BestSellerPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="bestseller"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/pages/foreign/index.tsx
+++ b/src/pages/foreign/index.tsx
@@ -12,7 +12,7 @@ import { carouselMockData } from '../api/mock/carouselMock';
 
 export default function DomesticPage() {
   return (
-      <SidebarLayout isDomestic={false}>
+      <SidebarLayout >
         <Spacing height={[0, 0, 20]} />
 
         <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
@@ -30,7 +30,7 @@ export default function DomesticPage() {
         </article>        
         <Spacing height={[120, 80, 80]} />
 
-        <CategoryBookList mainCategory="foreign"/>
+        <CategoryBookList />
       </SidebarLayout>
   );
 }

--- a/src/pages/foreign/newest/index.tsx
+++ b/src/pages/foreign/newest/index.tsx
@@ -2,14 +2,9 @@ import BookOverViewCardList from '@/components/card/bookOverviewCard/bookOverVie
 import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
-import { useRouter } from 'next/router';
 import Sidebar from '@/components/sidebar/sidebar';
-import { BestSellerPageProps } from '@/pages/domestic/bestseller';
 
-function NewestPage({ isDomestic = true }: BestSellerPageProps) {
-  const router = useRouter();
-  const { category } = router?.query;
-
+function NewestPage() {
   return (
     <div>
       <BestSellerPageLayout
@@ -17,8 +12,6 @@ function NewestPage({ isDomestic = true }: BestSellerPageProps) {
         sideBar={
           <Sidebar
             pageName="newest"
-            isDomestic={isDomestic}
-            location={category as string}
           />
         }
         main={

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,7 +1,23 @@
 import { atom } from 'jotai';
 
+import { getCategoryList } from '@/api/category';
+import { CategoryAtomType, CategoryType } from '@/types/api/category';
+
 export const countAtom = atom(0);
 
 export const pointVisibleAtom = atom(true);
 
 export const CurrentPageStateAtom = atom(1);
+
+// 맨 처음 카테고리 리스트 데이터를 받아와 저장하는 전역상태
+export const ReadonlyAtom = atom(1);
+export const CategoryListAtom = atom(async (get) => {
+  const readonly = get(ReadonlyAtom);
+  const result = await getCategoryList();
+  return result as CategoryAtomType;
+});
+
+// 내가 현재 위치한 카테고리 mainId, subId를 알려주는 전역상태
+export const LocatedCategoryAtom = atom<CategoryType>({
+  mainId: 0,
+});

--- a/src/types/api/category.ts
+++ b/src/types/api/category.ts
@@ -1,0 +1,15 @@
+// 카테고리 개별 타입
+export interface CategoryType{
+  mainId: number;
+  categoryId?: number;
+  subId?: number;
+  mainName?: string;
+  subName?: string;
+  link?: string;
+}
+
+// 전역상태로 관리하는 CategoryAtom 변수의 타입
+export interface CategoryAtomType{
+  domestic: CategoryType[];
+  foreign: CategoryType[];
+}

--- a/src/types/sidebarType.ts
+++ b/src/types/sidebarType.ts
@@ -2,6 +2,6 @@ export type pageNameType = "newest" | "bestseller";
 
 export interface SidebarProps {
   pageName?: pageNameType;
-  isDomestic: boolean;
+  isDomestic?: boolean;
   location?: string;
 }


### PR DESCRIPTION
## 구현사항

### 중요한 사안!!
#### 1. bestseller layout이랑 sidebar layout 사용하는 모든 페이지에 변경점 있습니다!!!!!!
#### 2. header의 link routing에 일부 수정점 있습니다!!!!!

1. 카테고리 사이드바의 카테고리데이터를 api로 불러오는 기능
3. jotai 전역관리로 카테고리 리스트 데이터를 관리.
4. jotai 전역관리로 현재 내가 위치한 페이지의 카테고리 mainId, subId를 관리. (예를 들어 내가 국내/과학 페이지에 있다면 locatedCategory state의 mainId값은 0, subId값은 뭐... 10? 이런 식으로 업데이트됨.
5. 이에 따른 불필요한 props 싹다 삭제. sidebarLayout, bestsellerLayout 을 사용하는 모든 페이지에 변경이 있습니다.
6. 전역상태 업데이트 훅 생성

-[] 구현한 내용 및 설명

디자인적 변경점은 하나도 없습니다!! 오로지 카테고리 api만 연결했습니다.

코드는 코멘트로 설명하겠습니다.

## 사용방법

- [ ] 카테고리 페이지나 신간, 베스트 셀레 페이지에 들어가서 사이드바 카테고리를 확인하면 됨.

## 스크린샷

이 부분을 api로 연결했다는 뜻!!

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/4eaf6575-5328-48f2-a28c-056dd401c3ce)


##### close #
