### PR TITLE
[#203] alertmodal수정

### DIFF
--- a/src/components/button/register/registerButton.tsx
+++ b/src/components/button/register/registerButton.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { MouseEventHandler } from 'react';
 
 type ButtonProps = {
@@ -6,8 +7,8 @@ type ButtonProps = {
   children: React.ReactNode;
   disabled?: boolean;
   color?: string;
-  height?: number;
-  text?: number;
+  height?: string;
+  text?: string;
 };
 
 function RegisterButton({
@@ -15,15 +16,16 @@ function RegisterButton({
   onClick,
   children,
   disabled = true,
-  color = 'green',
-  height = 50,
-  text = 17,
+  color = 'bg-green',
+  height = 'h-50',
+  text = 'text-17',
 }: ButtonProps) {
+  const buttonColor = `${!disabled ? 'bg-gray-2' : color}`;
+  const className = classNames("w-full text-center rounded-[5px] text-white py-8", buttonColor, text, height);
   return (
     <button
       type={type}
-      className={`h-${height} w-full text-center bg-${!disabled ? 'gray-2' : color} rounded-[5px] text-${text} text-white
-        py-8`}
+      className={className}
       onClick={onClick}
       disabled={!disabled}
       >

--- a/src/components/modal/addReview/titleContentTable.tsx
+++ b/src/components/modal/addReview/titleContentTable.tsx
@@ -26,7 +26,7 @@ function TitleContentTable({ title1, content1, title2, content2, truncate, butto
         <p className="w-full text-gray-3 font-light">{content2}</p>
       </div>
       {button && <div className="absolute w-50 top-0 right-0">
-        <RegisterButton height={36} text={14} onClick={onClick}>선택</RegisterButton>
+        <RegisterButton height='h-36' text='text-14' onClick={onClick}>선택</RegisterButton>
       </div>}
     </div>
   );

--- a/src/components/modal/alertModal/index.tsx
+++ b/src/components/modal/alertModal/index.tsx
@@ -16,10 +16,10 @@ function AlertModal({ title, description, onClick }: AlertModalProps) {
           <span className="text-16 font-light text-gray-3">{description}</span>
         </div>
         <div className="flex w-full gap-20">
-          <RegisterButton type="button" color="gray-2" onClick={onClick}>
+          <RegisterButton type="button" color="bg-gray-2" onClick={onClick}>
             취소
           </RegisterButton>
-          <RegisterButton type="button" color="red">
+          <RegisterButton type="button" color="bg-red">
             삭제
           </RegisterButton>
         </div>

--- a/src/components/modal/alertModal/index.tsx
+++ b/src/components/modal/alertModal/index.tsx
@@ -10,16 +10,16 @@ interface AlertModalProps {
 function AlertModal({ title, description, onClick }: AlertModalProps) {
   //TODO : community data fetching 연결되면 id값은 없어질 예정
   let id = 1
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: (id : number) => deleteCommunity(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries();
-    }
-  })
+  // const queryClient = useQueryClient();
+  // const mutation = useMutation({
+  //   mutationFn: (id : number) => deleteCommunity(id),
+  //   onSuccess: () => {
+  //     queryClient.invalidateQueries();
+  //   }
+  // })
 
   const handleDelete = (id : number) => {
-    mutation.mutate(id);
+    // mutation.mutate(id);
   }
 
   return (

--- a/src/components/modal/alertModal/index.tsx
+++ b/src/components/modal/alertModal/index.tsx
@@ -1,11 +1,27 @@
 import ModalLayout from '@/components/modal/modalLayout';
 import RegisterButton from '@/components/button/register/registerButton';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteCommunity } from '@/api/community';
 interface AlertModalProps {
   title: string;
   description: string;
   onClick: () => void;
 }
 function AlertModal({ title, description, onClick }: AlertModalProps) {
+  //TODO : community data fetching 연결되면 id값은 없어질 예정
+  let id = 1
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (id : number) => deleteCommunity(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    }
+  })
+
+  const handleDelete = (id : number) => {
+    mutation.mutate(id);
+  }
+
   return (
     <ModalLayout onClick={onClick}>
       <div
@@ -19,7 +35,7 @@ function AlertModal({ title, description, onClick }: AlertModalProps) {
           <RegisterButton type="button" color="bg-gray-2" onClick={onClick}>
             취소
           </RegisterButton>
-          <RegisterButton type="button" color="bg-red">
+          <RegisterButton type="button" color="bg-red" onClick={() => handleDelete(id)}>
             삭제
           </RegisterButton>
         </div>

--- a/src/components/modal/cart/cartModal.tsx
+++ b/src/components/modal/cart/cartModal.tsx
@@ -17,7 +17,7 @@ function CartModal({ title, description, onClick }: CartModalProps) {
           <span className="text-16 text-gray-3 font-light">{description}</span>
         </div>
         <div className="flex w-156">
-          <RegisterButton type="button" color="green" onClick={onClick}>
+          <RegisterButton type="button" onClick={onClick}>
             확인
           </RegisterButton>
         </div>


### PR DESCRIPTION
## 구현사항
- [x] alertmoal에 버튼 색상이 안나와서 registerbutton className을 classNames 라이브러리 사용해서 변경했습니다.
- [x] 삭제버튼에 deleteCommunity함수 mutation으로 연결했습니다.(해킹문제로 baseUrl 연결에러나서 주석처리했습니다) 

## 사용방법
- [x] registerbutton의 스타일 관련 props는 완전한 tailwind 스타일로 내려주시면 됩니다.
```
<RegisterButton color='green'  text={12} /> (x)
<RegisterButton color='bg-green' text='text-12' /> (o)
```

## 스크린샷
##### 변경 전
<img width="396" alt="스크린샷 2024-02-10 오후 8 57 37" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/dabe14cc-b1fc-4f66-a0a3-e4fe1316b91c">

#####  변경 후
<br/>
<img width="419" alt="스크린샷 2024-02-10 오후 9 28 36" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/3797a0ed-2ceb-481a-9732-3e5d475ae088">


##### close #203
