### PR TITLE
[#212] 마이페이지 스타일 리팩토링

### DIFF
--- a/src/components/card/bookOrderCard/bookOderEmptyCard.tsx
+++ b/src/components/card/bookOrderCard/bookOderEmptyCard.tsx
@@ -1,0 +1,5 @@
+function BookOverEmptyCard() {
+  return <div className="mx-auto py-130">아직 구매한 상품이 없어요!</div>;
+}
+
+export default BookOverEmptyCard;

--- a/src/components/card/bookOrderCard/bookOrderCard.tsx
+++ b/src/components/card/bookOrderCard/bookOrderCard.tsx
@@ -18,9 +18,7 @@ function BookOrderCard({ book, order }: BookOrderType) {
         className="relative h-102 min-w-102 bg-gray-1 text-center mobile:h-75 mobile:min-w-75">
         {book.imageUrl ? (
           <Image src={book.imageUrl} alt="책 표지 이미지" layout="fill" />
-        ) : (
-          <></>
-        )}
+        ) : null}
       </div>
       <div className="relative flex w-full flex-col items-start justify-start gap-12">
         <div className="flex w-full flex-col items-start justify-start gap-4">

--- a/src/components/card/bookOrderCard/bookOrderCardList.tsx
+++ b/src/components/card/bookOrderCard/bookOrderCardList.tsx
@@ -18,24 +18,32 @@ function BookOrderCardList({ orderData }: BookOrderCardListProps) {
   return (
     <div className="flex max-w-[1080px] flex-col">
       <div className="flex flex-col gap-40">
-        {orderData.map((orderData, index) => (
-          <div key={index} className="flex flex-col gap-20">
-            <OrderCount
-              orderCount={index + 1}
-              orderDate={orderData.orderDate}
-              orderId={orderData.orderId}
-            />
-            <div className="flex flex-col gap-20">
-              {orderData.bookData.map((bookData) => (
-                <BookOrderCard
-                  key={bookData.book.productId}
-                  book={bookData.book}
-                  order={bookData.order}
-                />
-              ))}
+        {orderData.map((order, index) => {
+          // orderData.bookData 배열 내의 모든 order.orderCount 값을 누적합산
+          const totalOrderCount = order.bookData.reduce(
+            (acc, curr) => acc + curr.order.orderCount,
+            0,
+          );
+
+          return (
+            <div key={index} className="flex flex-col gap-20">
+              <OrderCount
+                orderCount={totalOrderCount}
+                orderDate={order.orderDate}
+                orderId={order.orderId}
+              />
+              <div className="flex flex-col gap-20">
+                {order.bookData.map((bookData) => (
+                  <BookOrderCard
+                    key={bookData.book.productId}
+                    book={bookData.book}
+                    order={bookData.order}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/card/bookOrderCard/bookOrderEmptyCard.tsx
+++ b/src/components/card/bookOrderCard/bookOrderEmptyCard.tsx
@@ -1,5 +1,5 @@
-function BookOverEmptyCard() {
+function BookOrderEmptyCard() {
   return <div className="mx-auto py-130">아직 구매한 상품이 없어요!</div>;
 }
 
-export default BookOverEmptyCard;
+export default BookOrderEmptyCard;

--- a/src/components/card/bookReviewCard/myReviewCard.tsx
+++ b/src/components/card/bookReviewCard/myReviewCard.tsx
@@ -28,9 +28,7 @@ function MyReviewCard({ book, review }: MyReviewType) {
                 alt="book sample image"
                 layout="fill"
               />
-            ) : (
-              <></>
-            )}
+            ) : null}
           </div>
           <div className="flex w-4/5 flex-col items-start justify-start gap-4">
             <div

--- a/src/components/container/genreSection/genreSection.tsx
+++ b/src/components/container/genreSection/genreSection.tsx
@@ -15,7 +15,7 @@ function GenreSection() {
     if (isEditMode) {
       notify({
         type: 'success',
-        text: '선호장를 변경했어요 ⭐️',
+        text: '선호장르를 변경했어요 ⭐️',
       });
     }
   };

--- a/src/components/layout/bestSellerLayout.tsx
+++ b/src/components/layout/bestSellerLayout.tsx
@@ -28,7 +28,7 @@ function BestSellerPageLayout({
         <div role="header">{header}</div>
         <div
           role="sidebar-container"
-          className="max-w-[1200px] m-auto flex p-y-40 relative">
+          className="p-y-40 relative m-auto flex max-w-[1200px]">
           <section
             role="sidebar"
             className="flex h-full w-full flex-col items-start pl-245 pr-60 pt-40 mobile:px-15
@@ -42,14 +42,14 @@ function BestSellerPageLayout({
             </div>
             <div
               role="contents"
-              className="mobile:flex-center h-full w-full mobile:pt-30">
+              className="mobile:flex-center h-full w-full mobile:pt-30 ">
+              <div className="h-1" ref={ref} />
               {main}
+              <ScrollToTopButton />
             </div>
           </section>
         </div>
       </div>
-
-      <ScrollToTopButton />
     </>
   );
 }

--- a/src/components/layout/myOrderLayOut.tsx
+++ b/src/components/layout/myOrderLayOut.tsx
@@ -1,4 +1,8 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
+import ScrollToTopButton from '../button/scrollToTopButton';
+import { useAtom } from 'jotai';
+import { pointVisibleAtom } from '@/store/state';
+import useInfinite from '@/hooks/useInfinite';
 
 interface MyOrderPageLayoutProps {
   header?: ReactNode;
@@ -13,6 +17,12 @@ function MyOrderPageLayout({
   orderDate,
   main,
 }: MyOrderPageLayoutProps) {
+  const [ref, isIntersecting] = useInfinite();
+  const [, setPointVisible] = useAtom(pointVisibleAtom);
+
+  useEffect(() => {
+    setPointVisible(isIntersecting);
+  }, [isIntersecting]);
   return (
     <>
       <div role="container">
@@ -26,8 +36,10 @@ function MyOrderPageLayout({
           <div role="order-date" className="mb-20">
             {orderDate}
           </div>
-          <div role="content" className="">
+          <div role="content">
+            <div className="h-1" ref={ref} />
             {main}
+            <ScrollToTopButton />
           </div>
         </div>
       </div>

--- a/src/components/layout/settingPageLayout.tsx
+++ b/src/components/layout/settingPageLayout.tsx
@@ -13,14 +13,13 @@ function SettingPageLayout({
   isTopButton,
 }: SettingPageLayoutProps) {
   return (
-    
-      <div role="container" className="flex flex-col gap-40">
-        <div role="header">{header}</div>
-        <div role="content" className="flex-center">
-          {main}
-        </div>
-        {isTopButton && <ScrollToTopButton />}
+    <div role="container" className="flex flex-col gap-40">
+      <div role="header">{header}</div>
+      <div role="content" className="flex-center pb-40">
+        {main}
       </div>
+      {isTopButton && <ScrollToTopButton />}
+    </div>
   );
 }
 

--- a/src/components/profile/editProfile/editProfile.tsx
+++ b/src/components/profile/editProfile/editProfile.tsx
@@ -77,8 +77,8 @@ function EditProfile({
   return (
     <FormProvider {...method}>
       <div
-        className="max-h-745 mobile:360 w-440 rounded-[10px] border border-gray-1 bg-white
-          p-40 mobile:border-none">
+        className="max-h-745 mobile:360 w-440 rounded-[10px] border border-gray-1 bg-white p-40
+          mobile:border-none mobile:p-0 mobile:px-40">
         <div className="flex-center mb-40">
           <h1 className="text-20 font-bold"> 프로필 수정</h1>
         </div>

--- a/src/pages/mypage/order/index.tsx
+++ b/src/pages/mypage/order/index.tsx
@@ -1,32 +1,29 @@
-import BookOverEmptyCard from '@/components/card/bookOrderCard/bookOderEmptyCard';
+import BookOrderEmptyCard from '@/components/card/bookOrderCard/bookOrderEmptyCard';
 import BookOrderCardList from '@/components/card/bookOrderCard/bookOrderCardList';
 import OrderDate from '@/components/container/orderDate/orderDate';
 import OrderOverView from '@/components/container/orderDate/orderOverView';
 import Header from '@/components/header';
-import MainLayout from '@/components/layout/mainLayout';
 import MyOrderPageLayout from '@/components/layout/myOrderLayOut';
 import {
   bookOrderTestData,
   orderOverViewData,
 } from '@/pages/api/mock/bookOrderMock';
 const { orderData } = bookOrderTestData;
-// const orderData = undefined;
+
 function MyOrderPage() {
   return (
-    <>
-      <MyOrderPageLayout
-        header={<Header isLoggedIn numItemsOfCart={1} />}
-        // orderDate={<OrderDate />}
-        overview={<OrderOverView orderView={orderOverViewData.orderView} />}
-        main={
-          orderData ? (
-            <BookOrderCardList orderData={orderData} />
-          ) : (
-            <BookOverEmptyCard />
-          )
-        }
-      />
-    </>
+    <MyOrderPageLayout
+      header={<Header isLoggedIn numItemsOfCart={1} />}
+      // orderDate={<OrderDate />}
+      overview={<OrderOverView orderView={orderOverViewData.orderView} />}
+      main={
+        orderData ? (
+          <BookOrderCardList orderData={orderData} />
+        ) : (
+          <BookOrderEmptyCard />
+        )
+      }
+    />
   );
 }
 export default MyOrderPage;

--- a/src/pages/mypage/order/index.tsx
+++ b/src/pages/mypage/order/index.tsx
@@ -1,3 +1,4 @@
+import BookOverEmptyCard from '@/components/card/bookOrderCard/bookOderEmptyCard';
 import BookOrderCardList from '@/components/card/bookOrderCard/bookOrderCardList';
 import OrderDate from '@/components/container/orderDate/orderDate';
 import OrderOverView from '@/components/container/orderDate/orderOverView';
@@ -9,7 +10,7 @@ import {
   orderOverViewData,
 } from '@/pages/api/mock/bookOrderMock';
 const { orderData } = bookOrderTestData;
-
+// const orderData = undefined;
 function MyOrderPage() {
   return (
     <>
@@ -17,7 +18,13 @@ function MyOrderPage() {
         header={<Header isLoggedIn numItemsOfCart={1} />}
         // orderDate={<OrderDate />}
         overview={<OrderOverView orderView={orderOverViewData.orderView} />}
-        main={<BookOrderCardList orderData={orderData} />}
+        main={
+          orderData ? (
+            <BookOrderCardList orderData={orderData} />
+          ) : (
+            <BookOverEmptyCard />
+          )
+        }
       />
     </>
   );


### PR DESCRIPTION
## 구현사항

### 주문조회 페이지


- 스크롤 탑버튼 적용 
 ![스크린샷 2024-02-11 오후 3 44 10](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/0c8d4c40-0d50-474d-9542-29799ca6258f)]

요걸 추가 안해서 스크롤 탑 버튼이 안보였던 거였어용...ㅎㅎ 추가했더니 잘 먹힙니다.
베스트/신간 페이지에서는 페이지 집입하자마자 탑버튼이 떠서 역시 수정해두었습니다.

- 주문 n건 메시지 수정
![스크린샷 2024-02-11 오후 3 48 09](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/7fe85cd0-61d7-4d2e-97c9-a9920a1cc941)

기존 주문 n건: 주문 자체의 횟수 -> 변경된 주문 n건: 주문한 책들의 총 권수
현재는 reduce메서드를 사용했으나, 처음부터 서버데이터에 totalCount가 있으면 더 편할것 같긴합니당


- 주문이 없을때 보여줄 컴포넌트 제작 (components/card/bookOrderCard/BookOrderEmptyCard.tsx)
<img width="761" alt="스크린샷 2024-02-11 오후 3 22 40" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/6d368727-e056-47fc-8942-03d3b1a7e90f">


### 선호장르 선택 페이지
- 토스트 메시지 오타 수정
- 너무 바닥에 붙어보이지 않게 padding bottom적용 

### 비밀번호 변경 페이지 & 선호장르 변경 페이지

- 너무 바닥에 붙어보이지 않게 padding bottom적용 

### MyOrderCard 컴포넌트
![스크린샷 2024-02-11 오후 3 52 46](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/c38df4ed-14b9-43bd-8be3-1613f747feda)

![스크린샷 2024-02-11 오후 3 53 00](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/c2cf5f0c-2208-4e99-b444-7dde37ec7df4)

- 삼항연산자 사용 부분에 <></> 대신 null 값 적용



## 사용방법

## 스크린샷

##### close #212 
