### PR TITLE
[#209] 결제페이지 3번 UI

### DIFF
--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -1,0 +1,18 @@
+import TermsCheckbox from "@/components/container/terms/terms";
+import TotalPrice from "./totalPrice"
+import RegisterButton from "@/components/button/register/registerButton";
+
+function TotalPriceCard() {
+  return (
+    <div>
+      <TotalPrice title="총 상풒 금액" price="23500" />
+      <TotalPrice title="총 배송비" price="+3000" />
+      <TotalPrice title="총 할일 금액" price="-3000" />
+      <TotalPrice title="결제 금액" price="23500" />
+      <TermsCheckbox />
+      <RegisterButton>23500원 결제하기</RegisterButton>
+    </div>
+  );
+}
+
+export default TotalPriceCard

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -1,15 +1,16 @@
 import TermsCheckbox from "@/components/container/terms/terms";
-import TotalPrice from "./totalPrice"
+import TotalPrice from "@/components/card/totalPaymentCard/totalPrice"
 import RegisterButton from "@/components/button/register/registerButton";
+import { REQUIRED_FOR_PAYMENT } from "src/constants/sign";
 
 function TotalPriceCard() {
   return (
-    <div>
+    <div className="flex flex-col w-432 gap-20">
       <TotalPrice title="총 상풒 금액" price="23500" />
       <TotalPrice title="총 배송비" price="+3000" />
       <TotalPrice title="총 할일 금액" price="-3000" />
       <TotalPrice title="결제 금액" price="23500" />
-      <TermsCheckbox />
+      <TermsCheckbox entire="전체동의(필수)" checkContent={REQUIRED_FOR_PAYMENT} useFormContextProps={false} showLastButton={true} />
       <RegisterButton>23500원 결제하기</RegisterButton>
     </div>
   );

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -3,15 +3,18 @@ import TotalPrice from "@/components/card/totalPaymentCard/totalPrice"
 import RegisterButton from "@/components/button/register/registerButton";
 import { REQUIRED_FOR_PAYMENT } from "src/constants/sign";
 
+//TODO : TotalPrice컴포넌트의 price props, RegisterButton 가격 TotalPriceCardProps로 받아야함
 function TotalPriceCard() {
   return (
-    <div className="flex flex-col w-432 gap-20">
+    <div className="flex flex-col w-432 gap-20 p-30 tablet:w-688 mobile:w-330 mobile:p-20">
       <TotalPrice title="총 상풒 금액" price="23500" />
       <TotalPrice title="총 배송비" price="+3000" />
       <TotalPrice title="총 할일 금액" price="-3000" />
-      <TotalPrice title="결제 금액" price="23500" />
-      <TermsCheckbox entire="전체동의(필수)" checkContent={REQUIRED_FOR_PAYMENT} useFormContextProps={false} showLastButton={true} />
-      <RegisterButton>23500원 결제하기</RegisterButton>
+      <TotalPrice title="결제 금액" price="23500" font="font-bold" text='text-20'/>
+      <TermsCheckbox entire="전체동의(필수)" checkContent={REQUIRED_FOR_PAYMENT} useFormContextProps={false} showLastButton={false} />
+      <div className="tablet:hidden mobile:hidden">
+        <RegisterButton>23500원 결제하기</RegisterButton>
+      </div>
     </div>
   );
 }

--- a/src/components/card/totalPaymentCard/totalPrice.tsx
+++ b/src/components/card/totalPaymentCard/totalPrice.tsx
@@ -1,0 +1,14 @@
+function TotalPrice({ title, price } : { title: string; price: string; }) {
+  return (
+    <div className="flex justify-between items-center text-15">
+      <span className="font-light">
+        {title}
+      </span>
+      <span className="font-bold">
+        {price}
+      </span>
+    </div>
+  )
+}
+
+export default TotalPrice

--- a/src/components/card/totalPaymentCard/totalPrice.tsx
+++ b/src/components/card/totalPaymentCard/totalPrice.tsx
@@ -1,14 +1,23 @@
-function TotalPrice({ title, price } : { title: string; price: string; }) {
+import cls from "@/utils/cls";
+
+interface TotalPriceProps {
+  title: string;
+  price: string;
+  font?: string;
+  text?: string;
+}
+
+function TotalPrice({ title, price, font, text }: TotalPriceProps) {
+  console.log(font)
   return (
-    <div className="flex justify-between items-center text-15">
-      <span className="font-light">
-        {title}
-      </span>
-      <span className="font-bold">
+    <div className="flex items-center justify-between text-15">
+      <span className={cls(`${font ? font : 'font-light'}`)}>{title}</span>
+      <span
+        className={cls(`${text ? `${text} font-bold` : 'text-15 font-bold'}`)}>
         {price}
       </span>
     </div>
-  )
+  );
 }
 
 export default TotalPrice

--- a/src/components/container/terms/terms.tsx
+++ b/src/components/container/terms/terms.tsx
@@ -3,22 +3,28 @@ import React, { FormEvent, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import CheckIcon from '@/public/icons/CheckIcon.svg';
 import RightArrowIcon from '@/public/icons/RightArrow.svg';
-import { TERMS_TITLES } from 'src/constants/sign';
 
+interface TermsCheckboxProps {
+  title?: string;
+  entire: string;
+  checkContent: string[];
+  useFormContextProps?: boolean;
+  showLastButton?: boolean;
+}
 interface CheckedStates {
   [key: string]: boolean;
 }
 
-function TermsCheckbox() {
-  const { register, setValue } = useFormContext();
-
+function TermsCheckbox({ title, entire, checkContent, useFormContextProps = true, showLastButton = true }: TermsCheckboxProps) {
+  const formMethods = useFormContextProps ? useFormContext() : null
+  
   const [checkedStates, setCheckedStates] = useState<CheckedStates>(
-    TERMS_TITLES.reduce((acc, title) => ({ ...acc, [title]: false }), {}),
+    checkContent.reduce((acc, title) => ({ ...acc, [title]: false }), {}),
   );
   const handleSelectAll = (e: FormEvent<HTMLInputElement>) => {
     const isChecked = e.currentTarget.checked;
     setCheckedStates(
-      TERMS_TITLES.reduce(
+      checkContent.reduce(
         (acc, termsTitle) => ({ ...acc, [termsTitle]: isChecked }),
         {},
       ),
@@ -34,12 +40,12 @@ function TermsCheckbox() {
 
   useEffect(() => {
     const isAllChecked = Object.values(checkedStates).every(Boolean);
-    setValue('selectAll', isAllChecked);
-  }, [checkedStates, setValue]);
+    formMethods?.setValue('selectAll', isAllChecked);
+  }, [checkedStates, formMethods?.setValue]);
 
   return (
-    <div className="w-360 mobile:w-330">
-      <span className="inline-block pb-8 font-bold">약관동의</span>
+    <div className="w-full">
+      {title && <span className="inline-block pb-8 font-bold">{title}</span>}
       <div className="relative flex h-48 items-center gap-8 border-0 border-b-[1px] border-b-[#DBDBDB]">
         <label htmlFor="selectAll" className="font-medium text-15">
           <Image
@@ -52,24 +58,22 @@ function TermsCheckbox() {
           <input
             type="checkbox"
             id="selectAll"
-            {...register('selectAll')}
+            {...formMethods?.register('selectAll')}
             checked={Object.values(checkedStates).every(Boolean)}
             onChange={handleSelectAll}
-            className="mt-0.5 relative float-left mr-8 h-20 w-20 appearance-none rounded-full border-2 border-solid
+            className="mt-0.5 relative float-left mr-8 h-20 w-20 appearance-none rounded-[2px] border-2 border-solid
               border-gray-3 p-1 checked:border-0 checked:bg-green"
           />
-          전체 동의
+          {entire}
         </label>
       </div>
 
       <div>
-        {TERMS_TITLES.map((termsTitle) => (
-          <div
-            key={termsTitle}
-            className="flex h-48 items-center justify-between">
+        {checkContent.map((content, index) => (
+          <div key={content} className="flex h-48 items-center justify-between">
             <div className="relative flex items-center">
               <label
-                htmlFor={`id.${termsTitle}`}
+                htmlFor={`id.${content}`}
                 className="text-15 text-[#767676]">
                 <Image
                   src={CheckIcon}
@@ -79,25 +83,27 @@ function TermsCheckbox() {
                   className="absolute left-5 top-7 z-10"
                 />
                 <input
-                  id={`id.${termsTitle}`}
-                  {...register(`id.${termsTitle}`)}
+                  id={`id.${content}`}
+                  {...formMethods?.register(`id.${content}`)}
                   type="checkbox"
-                  checked={checkedStates[termsTitle]}
-                  onChange={() => handleIndividualCheck(termsTitle)}
-                  className="mt-0.5 relative float-left mr-8 h-20 w-20 appearance-none rounded-full border-2 border-solid
+                  checked={checkedStates[content]}
+                  onChange={() => handleIndividualCheck(content)}
+                  className="mt-0.5 relative float-left mr-8 h-20 w-20 appearance-none rounded-[2px] border-2 border-solid
                     border-gray-3 p-1 checked:border-0 checked:bg-green"
                 />
-                {termsTitle}
+                {content}
               </label>
             </div>
-            <button className="pr-4" onClick={handleOpenModal}>
-              <Image
-                src={RightArrowIcon}
-                width={18}
-                height={18}
-                alt="약관내용 전체보기 버튼"
-              />
-            </button>
+            {(showLastButton || index !== checkContent.length - 1) && (
+              <button className="pr-4" onClick={handleOpenModal}>
+                <Image
+                  src={RightArrowIcon}
+                  width={18}
+                  height={18}
+                  alt="약관내용 전체보기 버튼"
+                />
+              </button>
+            )}
           </div>
         ))}
       </div>

--- a/src/components/container/terms/terms.tsx
+++ b/src/components/container/terms/terms.tsx
@@ -70,8 +70,8 @@ function TermsCheckbox({ title, entire, checkContent, useFormContextProps = true
 
       <div>
         {checkContent.map((content, index) => (
-          <div key={content} className="flex h-48 items-center justify-between">
-            <div className="relative flex items-center">
+          <div key={content} className="flex h-48 items-center justify-between gap-5">
+            <div className="relative flex items-center gap-8">
               <label
                 htmlFor={`id.${content}`}
                 className="text-15 text-[#767676]">

--- a/src/components/container/terms/terms.tsx
+++ b/src/components/container/terms/terms.tsx
@@ -29,7 +29,7 @@ function TermsCheckbox() {
   };
 
   const handleOpenModal = () => {
-    //모달을 열거예용
+    //TODO : 모달을 열거예용
   };
 
   useEffect(() => {

--- a/src/constants/sign.ts
+++ b/src/constants/sign.ts
@@ -3,3 +3,9 @@ export const TERMS_TITLES = [
   '이용약관',
   '개인정보 수집 및 이용동의',
 ];
+
+export const REQUIRED_FOR_PAYMENT = [
+  '개인정보 수집 이용 및 제 3자 제공 동의',
+  '결제대행 서비스 이용약관 동의',
+  '본인은 만 14세 이상이며, 주문 내용을 확인하였습니다.'
+]

--- a/src/constants/sign.ts
+++ b/src/constants/sign.ts
@@ -5,7 +5,7 @@ export const TERMS_TITLES = [
 ];
 
 export const REQUIRED_FOR_PAYMENT = [
-  '개인정보 수집 이용 및 제 3자 제공 동의',
+  '개인정보 수집이용 및 제3자 제공 동의',
   '결제대행 서비스 이용약관 동의',
   '본인은 만 14세 이상이며, 주문 내용을 확인하였습니다.'
 ]

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/utils/checkSignInSignOut';
 import Link from 'next/link';
 import { FormProvider, useForm } from 'react-hook-form';
+import { TERMS_TITLES } from 'src/constants/sign';
 
 function SignUp() {
   const method = useForm<SignUpValueType>({
@@ -153,7 +154,7 @@ function SignUp() {
               </div>
             </fieldset>
             <fieldset className="mb-20">
-              <TermsCheckbox />
+              <TermsCheckbox title='약관동의' entire='전체동의' checkContent={TERMS_TITLES}/>
             </fieldset>
             <RegisterButton>회원가입</RegisterButton>
           </form>

--- a/src/pages/test/payment/index.tsx
+++ b/src/pages/test/payment/index.tsx
@@ -1,0 +1,11 @@
+import TotalPriceCard from "@/components/card/totalPaymentCard"
+
+function Payment() {
+  return (
+    <>
+      <TotalPriceCard />
+    </>
+  )
+}
+
+export default Payment


### PR DESCRIPTION
## 구현사항
- #209

## 사용방법
```
//TODO : TotalPrice컴포넌트의 price props, RegisterButton 가격 TotalPriceCardProps로 받아야함
function TotalPriceCard() {
  return (
    <div className="flex flex-col w-432 gap-20 p-30 tablet:w-688 mobile:w-330 mobile:p-20">
      <TotalPrice title="총 상풒 금액" price="23500" />
      <TotalPrice title="총 배송비" price="+3000" />
      <TotalPrice title="총 할일 금액" price="-3000" />
      <TotalPrice title="결제 금액" price="23500" font="font-bold" text='text-20'/>
      <TermsCheckbox entire="전체동의(필수)" checkContent={REQUIRED_FOR_PAYMENT} useFormContextProps={false} showLastButton={false} />
      <div className="tablet:hidden mobile:hidden">
        <RegisterButton>23500원 결제하기</RegisterButton>
      </div>
    </div>
  );
}
```
<br/>
밑에 스크린샷 한줄(빨간박스)은 totalPrice 컴포넌트임
<img width="361" alt="스크린샷 2024-02-12 오전 12 14 07" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/b69a3838-3a4e-4c75-99cc-8b96c8d066c4">

- [ ] page조립 후 price에 값을 내려줄 예정임.(todo로 적어둠)
- [ ] 결제 하기 버튼시 api 연결  필요함

TermsCheckbox는 회원가입에서 체크박스랑 동일해서, 
- 배열 변수 수정
- form이 필요없는 곳에서는 useFormContext에러나지 않게 삼항연산자 추가
- 약관내용 전체보기 버튼이 필요없을때 안보이게 showLastButton props 추가
- 마지막 register button은 모바일과, 테블릿환경에서는 보이지않음

## 스크린샷

https://github.com/bookstore-README/front_bookstore-README/assets/138510303/6d0858e8-e95e-44dd-8d18-ef36f16b7bb5



##### close #209
##### close #229