### PR TITLE
[#232] fix: header꽉차보이게 페이지(찜, 장바구니, 맞춤) 레이아웃 수정

### DIFF
--- a/src/pages/bookmarked/index.tsx
+++ b/src/pages/bookmarked/index.tsx
@@ -94,9 +94,9 @@ function BookMarkedPage() {
   };
 
   return (
-    <div className="flex w-full flex-col items-center">
-      <div className="w-full max-w-[1200px]">
-        <MainLayout>
+    <div className="flex w-full flex-col items-center"> 
+      <MainLayout>
+        <div className="w-full max-w-[1200px]">
           <div className="flex w-full flex-col px-60 mobile:px-15 tablet:px-40">
             <div className="text-20 font-bold text-black">
               찜목록{wishListData.length > 0 && `(${wishListData.length})`}
@@ -194,8 +194,8 @@ function BookMarkedPage() {
               </div>
             )}
           </div>
-        </MainLayout>
-      </div>
+          </div>
+        </MainLayout>  
       <div ref={ref} />
     </div>
   );

--- a/src/pages/cart/index.tsx
+++ b/src/pages/cart/index.tsx
@@ -135,8 +135,9 @@ function CartPage() {
 
   return (
     <div className="flex w-full flex-col items-center">
-      <div className="w-full max-w-[1200px]">
-        <MainLayout>
+   
+      <MainLayout>
+           <div className="w-full max-w-[1200px]">
           <div className="relative w-full">
             <div
               className="flex gap-x-30 px-60 mobile:flex-col mobile:gap-x-10 mobile:px-15 tablet:gap-x-20
@@ -296,9 +297,9 @@ function CartPage() {
               />
             </div>
           </div>
+          </div>
         </MainLayout>
-      </div>
-    </div>
+      </div>  
   );
 }
 

--- a/src/pages/custom/index.tsx
+++ b/src/pages/custom/index.tsx
@@ -53,9 +53,9 @@ function CustomPage() {
 
   return (
     <div className="flex-1">
-      <div className="w-full flex flex-col items-center">
-        <div className="max-w-[1200px] w-full">
-          <MainLayout>
+      <div className="w-full flex flex-col items-center">        
+        <MainLayout>
+            <div className="max-w-[1200px] w-full">
             <CustomPageContentsLayout>
               <div
                 className="flex flex-wrap w-full gap-8 mt-30 mb-40 mobile:flex-nowrap
@@ -126,10 +126,10 @@ function CustomPage() {
                 })}
               </div>
             </CustomPageContentsLayout>
+            </div>
           </MainLayout>
         </div>
-      </div>
-    </div>
+      </div>     
   );
 }
 


### PR DESCRIPTION
## 구현사항

-[] 구현한 내용 및 설명
- header꽉차보이게 페이지(찜, 장바구니, 맞춤) 레이아웃 수정
## 사용방법

## 스크린샷
<img width="954" alt="image" src="https://github.com/bookstore-README/front_bookstore-README/assets/86518113/002dca43-172b-42cd-955a-3186ae6bfcc5">

##### close #232 
