### PR TITLE
[#162] 제품상세페이지 api 연결

### DIFF
--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -7,36 +7,58 @@ import StaticOrderNavigator from '@/components/orderNavigator/staticOrderNavigat
 
 interface BookDetailCardProps {
   bookId: string;
+  bookImgUrl: string;
+  bookTitle: string;
+  price: number;
+  categories: [string, string];
+  authors: string[];
+  bookmarkCount: number;
+  isBookmarked: boolean;
+  publishedAt: string;
+  publisher: string;
+  rating: number;
+  reviewNum: number;
   orderCount: number;
   setOrderCount: (n: number) => void;
 }
 
 function BookDetailCard({
   bookId,
+  bookImgUrl,
+  bookTitle,
+  price,
+  categories,
+  authors,
+  bookmarkCount,
+  isBookmarked,
+  publishedAt,
+  publisher,
+  rating,
+  reviewNum,
   orderCount,
   setOrderCount,
 }: BookDetailCardProps) {
   return (
     <section className="flex justify-start gap-20 items-start mobile:flex-col mobile:flex-center">
-      <BookDetailImg imageUrl={Mock.imageUrl} />
+      <BookDetailImg imageUrl={bookImgUrl} />
       <article
         role="info"
         className="flex flex-col gap-57 justify-start items-start mobile:w-full">
         <BookDetailInfo
-          title={Mock.title}
-          categoryList={Mock.categoryList}
-          authors={Mock.authors}
-          isBookmarked={Mock.isBookmarked}
-          bookmarkNum={Mock.bookmarkNum}
-          publishedAt={Mock.publishedAt}
-          publisher={Mock.publisher}
-          rating={Mock.rating}
-          reviewNum={Mock.reviewNum}
-          price={Mock.price}
+          title={bookTitle}
+          categoryList={categories}
+          authors={authors}
+          isBookmarked={isBookmarked}
+          bookmarkNum={bookmarkCount}
+          publishedAt={publishedAt}
+          publisher={publisher}
+          rating={rating}
+          reviewNum={reviewNum}
+          price={price}
         />
         <StaticOrderNavigator
           bookId={bookId}
-          price={Mock.price}
+          price={price}
           orderCount={orderCount}
           setOrderCount={setOrderCount}
         />

--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -1,6 +1,5 @@
 /** 책 상세페이지에 들어갈 카드 컴포넌트 */
 
-import { BookDetailMock1 as Mock } from '@/pages/api/mock/bookDetailMock';
 import BookDetailImg from './bookDetailImg';
 import BookDetailInfo from './bookDetailInfo';
 import StaticOrderNavigator from '@/components/orderNavigator/staticOrderNavigator';
@@ -16,7 +15,7 @@ interface BookDetailCardProps {
   isBookmarked: boolean;
   publishedAt: string;
   publisher: string;
-  rating: number;
+  averageRating: number;
   reviewNum: number;
   orderCount: number;
   setOrderCount: (n: number) => void;
@@ -33,7 +32,7 @@ function BookDetailCard({
   isBookmarked,
   publishedAt,
   publisher,
-  rating,
+  averageRating,
   reviewNum,
   orderCount,
   setOrderCount,
@@ -52,7 +51,7 @@ function BookDetailCard({
           bookmarkNum={bookmarkCount}
           publishedAt={publishedAt}
           publisher={publisher}
-          rating={rating}
+          rating={averageRating}
           reviewNum={reviewNum}
           price={price}
         />

--- a/src/components/container/categoryBookList/mainCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/mainCategoryBookList.tsx
@@ -29,6 +29,7 @@ function MainCategoryBookList() {
     endpoint: `${locatedCategory.mainId}/main`,
     queryKey: [selectedOrder, String(locatedCategory.mainId), "main-category-book-list"],
     queryFunc: getBook,
+    initialCursorId: 0,
     cursorName: "bookId",
     sort: currentOrder.sort,
     ascending: currentOrder.ascending,

--- a/src/components/orderNavigator/sideOrderNavigator.tsx
+++ b/src/components/orderNavigator/sideOrderNavigator.tsx
@@ -7,7 +7,6 @@ interface SideOrderNavigatorProps {
   orderCount: number;
   setOrderCount: (s: number) => void;
   price: number;
-  bookId: string;
   isBookmarked: boolean;
 }
 
@@ -15,7 +14,6 @@ function SideOrderNavigator({
   orderCount,
   setOrderCount,
   price,
-  bookId,
   isBookmarked,
 }: SideOrderNavigatorProps) {
   const [checkBookmarked, setIsBookmarked] = useState(isBookmarked || false);

--- a/src/components/review/review.tsx
+++ b/src/components/review/review.tsx
@@ -6,9 +6,13 @@ import { ReviewListMock1 } from '@/pages/api/mock/bookDetailMock';
 import ReviewOverviewCard from '../card/bookReviewCard/reviewOverviewCard';
 import BookReviewCard from '../card/bookReviewCard/bookReviewCard';
 
-function Review({ bookId = '' }) {
-  // TODO react query를 통해 book 상세 정보와 review 리스트를 받아올 것
-
+interface ReviewProps {
+  reviewNum: number;
+  rating?: number;
+  ratingDist?: [number, number, number, number, number];
+  reviewList?: any[];
+}
+function Review({ reviewNum, rating=0, ratingDist=[0,0,0,0,0], reviewList = [] }: ReviewProps) {
   return (
     <section className="mobile:flex-center flex flex-col gap-20">
       <h3
@@ -16,16 +20,16 @@ function Review({ bookId = '' }) {
           text-gray-4 mobile:w-330">
         리뷰
         <span className="pl-10 text-20 font-bold text-green">
-          {ReviewListMock1.reviewNum}
+          {reviewNum}
         </span>
       </h3>
       <ReviewOverviewCard
-        rating={ReviewListMock1.averageRating}
-        reviewNum={ReviewListMock1.reviewNum}
-        ratingDist={ReviewListMock1.ratingDist}
+        rating={rating}
+        reviewNum={reviewNum}
+        ratingDist={ratingDist}
       />
       <article className="flex flex-col gap-20 w-full pt-40 mobile:flex-center mobile:gap-10">
-        {ReviewListMock1.reviewList.map((el) => {
+        {reviewList.map((el) => {
           return (
             <BookReviewCard
               key={el.reviewId}

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -29,24 +29,32 @@ export default function BookDetailPage() {
   })
 
   // TODO isLoading 에선 스켈레톤 ui 보여주게 할 것.
+  // TODO 로그인 안된 경우 찜 버튼 못 누르게 혹은 로그인하라는 alert 창 뜨게
+  // TODO 상품정보 이거 어쩌징
+  // TODO 리뷰가 없을 때 보여줄 이미지 뭐 리뷰가 없어요! 이런거 만들기
+  // TODO 로그인한경우 찜되게끔 찜 버튼 연결
+  // TODO 로그인한경우 조회수 올라가게 조회수 api 연결
+  // TODO 공유하기버튼 연결
+  // TODO 장바구니, 구매하기 버튼 연결
+  // TODO 백엔드님 averageRating이랑 ratingDist 값도 넘겨주세요
+  // TODO 백엔드님 이거 이미지 화질 이게 최선이겠죠??ㅠ ㅠㅠㅠㅠ
+  // TODO 백엔드님리뷰가 하나도 없어서 리뷰 페이지네이션이나 리뷰 정렬 기능을 구현 못하고 있는데 혹시 리뷰 랜덤 데이터좀 넣어주실수 있나요 ㅠ
   return (
     <MainLayout>
         <section className="flex flex-col w-full p-40 mobile:p-19 mobile:flex-center">
           <BookDetailCard
-          bookId={bookId as string}
-          bookImgUrl={data?.data.bookImgUrl ?? "/"}
-          bookTitle={data?.data.bookTitle ?? ""}
-          price={data?.data.price ?? 0}
-          categories={data?.data.categories ?? ["",""]}
-          authors={data?.data.authors ??[""]}
-          bookmarkCount={data?.data.bookmarkCount ?? 0}
-          
-          isBookmarked={data?.data.isBookmarked ?? false}
-          publishedAt={data?.data.publishedDate ?? ""}
-          publisher={data?.data.publisher ?? ""}
-          rating={data?.data?.rating ?? 0}
-          reviewNum={data?.data.reviewCount ?? 0}
-
+            bookId={bookId as string}
+            bookImgUrl={data?.data.bookImgUrl ?? "/"}
+            bookTitle={data?.data.bookTitle ?? ""}
+            price={data?.data.price ?? 0}
+            categories={data?.data.categories ?? ["",""]}
+            authors={data?.data.authors ??[""]}
+            bookmarkCount={data?.data.bookmarkCount ?? 0}
+            isBookmarked={data?.data.isBookmarked ?? false}
+            publishedAt={data?.data.publishedDate ?? ""}
+            publisher={data?.data.publisher ?? ""}
+            rating={data?.data?.rating ?? 0}
+            reviewNum={data?.data.reviewCount ?? 0}
             orderCount={orderCount}
             setOrderCount={setOrderCount}
           />
@@ -63,14 +71,13 @@ export default function BookDetailPage() {
               mobile:flex-center">
             <div className="flex flex-col w-full max-w-[710px] mobile:flex-center">
               {location === 'information' && <BookInformation />}
-              {location === 'review' && <Review bookId={bookId as string} />}
+            {location === 'review' && <Review reviewNum={data?.data?.reviewCount} reviewList={data?.data?.reviews} />}
               {location === 'currency' && <RefundTerm />}
             </div>
             <div className="pc:pt-50 pc:flex hidden">
               <SideOrderNavigator
                 isBookmarked={data?.data.isBookmarked ?? false}
                 price={data?.data.price ?? 0}
-                bookId={bookId as string}
                 orderCount={orderCount}
                 setOrderCount={setOrderCount}
               />

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -36,9 +36,6 @@ export default function BookDetailPage() {
   // TODO 로그인한경우 조회수 올라가게 조회수 api 연결
   // TODO 공유하기버튼 연결
   // TODO 장바구니, 구매하기 버튼 연결
-  // TODO 백엔드님 averageRating이랑 ratingDist 값도 넘겨주세요
-  // TODO 백엔드님 이거 이미지 화질 이게 최선이겠죠??ㅠ ㅠㅠㅠㅠ
-  // TODO 백엔드님리뷰가 하나도 없어서 리뷰 페이지네이션이나 리뷰 정렬 기능을 구현 못하고 있는데 혹시 리뷰 랜덤 데이터좀 넣어주실수 있나요 ㅠ
   return (
     <MainLayout>
         <section className="flex flex-col w-full p-40 mobile:p-19 mobile:flex-center">
@@ -53,7 +50,7 @@ export default function BookDetailPage() {
             isBookmarked={data?.data.isBookmarked ?? false}
             publishedAt={data?.data.publishedDate ?? ""}
             publisher={data?.data.publisher ?? ""}
-            rating={data?.data?.rating ?? 0}
+            averageRating={data?.data?.averageRating ?? 0}
             reviewNum={data?.data.reviewCount ?? 0}
             orderCount={orderCount}
             setOrderCount={setOrderCount}

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -1,17 +1,17 @@
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 
+import { useGetBook } from '@/api/book';
 import MainLayout from '@/components/layout/mainLayout';
 import BookDetailCard from '@/components/card/bookDetailCard/bookDetailCard';
 import BookDetailNav from '@/components/button/bookDetailNav';
-import { BookDetailMock1 } from '../api/mock/bookDetailMock';
-import { useState } from 'react';
-import { BookDetailNavLocationType } from '@/types/bookDetailtype';
 import RefundTerm from '@/components/container/refundTerm/refundTerm';
 import BookInformation from '@/components/book/bookInformation/bookInformation';
 import Review from '@/components/review/review';
 import Spacing from '@/components/container/spacing/spacing';
 import SideOrderNavigator from '@/components/orderNavigator/sideOrderNavigator';
 import FooterOrderNavitgator from '@/components/orderNavigator/footerOrderNavitgator';
+import { BookDetailNavLocationType } from '@/types/bookDetailtype';
 
 export default function BookDetailPage() {
   const router = useRouter();
@@ -21,19 +21,39 @@ export default function BookDetailPage() {
     useState<BookDetailNavLocationType>('information');
   // 책 구매 수량 state
   const [orderCount, setOrderCount] = useState(1);
+  const {data, isLoading, isError} = useGetBook({
+      endpoint: `${bookId}/detail`,
+      params: {
+        bookId: String(bookId)
+      },
+  })
 
+  // TODO isLoading 에선 스켈레톤 ui 보여주게 할 것.
   return (
     <MainLayout>
         <section className="flex flex-col w-full p-40 mobile:p-19 mobile:flex-center">
           <BookDetailCard
-            bookId={bookId as string}
+          bookId={bookId as string}
+          bookImgUrl={data?.data.bookImgUrl ?? "/"}
+          bookTitle={data?.data.bookTitle ?? ""}
+          price={data?.data.price ?? 0}
+          categories={data?.data.categories ?? ["",""]}
+          authors={data?.data.authors ??[""]}
+          bookmarkCount={data?.data.bookmarkCount ?? 0}
+          
+          isBookmarked={data?.data.isBookmarked ?? false}
+          publishedAt={data?.data.publishedDate ?? ""}
+          publisher={data?.data.publisher ?? ""}
+          rating={data?.data?.rating ?? 0}
+          reviewNum={data?.data.reviewCount ?? 0}
+
             orderCount={orderCount}
             setOrderCount={setOrderCount}
           />
         </section>
         <Spacing height={[80, 80, 40]} />
         <BookDetailNav
-          reviewNum={BookDetailMock1.reviewNum}
+          reviewNum={data?.data.reviewCount}
           location={location}
           setLocation={setLocation}
         />
@@ -48,8 +68,8 @@ export default function BookDetailPage() {
             </div>
             <div className="pc:pt-50 pc:flex hidden">
               <SideOrderNavigator
-                isBookmarked={BookDetailMock1.isBookmarked}
-                price={BookDetailMock1.price}
+                isBookmarked={data?.data.isBookmarked ?? false}
+                price={data?.data.price ?? 0}
                 bookId={bookId as string}
                 orderCount={orderCount}
                 setOrderCount={setOrderCount}
@@ -57,8 +77,8 @@ export default function BookDetailPage() {
             </div>
           </section>
           <FooterOrderNavitgator
-            isBookmarked={BookDetailMock1.isBookmarked}
-            price={BookDetailMock1.price}
+            isBookmarked={data?.data.isBookmarked ?? false}
+            price={data?.data.price ?? 0}
             bookId={bookId as string}
             orderCount={orderCount}
             setOrderCount={setOrderCount}


### PR DESCRIPTION
## 구현사항

bookdetail 페이지 제품 상세 데이터 연결했습니다.

-[] 구현한 내용 및 설명

외관 바뀐 거 하나도 없고 데이터만 연결함.

## 사용방법

localhost:3000/domestic 에서 아래로 쭉 내리다보면 모든 도서들이 나오는데, 아무거나 클릭하면 bookdetail 페이지로 넘어갑니다!!

아니면 localhost:3000/bookdetail/아무 책 번호

이렇게 접근할 수 있습니다!!

## 스크린샷

![Honeycam 2024-02-14 15-42-45](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/47a00919-f089-40bd-a686-617cfa0a3436)

## 이후 해야할 것

좀 많습니다..

  // TODO isLoading 에선 스켈레톤 ui 보여주게 할 것.
  // TODO 로그인 안된 경우 찜 버튼 못 누르게 혹은 로그인하라는 alert 창 뜨게
  // TODO 상품정보 이거 어쩌징... 
  // TODO 리뷰가 없을 때 보여줄 이미지 뭐 리뷰가 없어요! 이런거 만들기
  // TODO 로그인한 경우 찜되게끔 찜 버튼 연결
  // TODO 로그인한 경우 조회수 올라가게 조회수 api 연결
  // TODO 공유하기 버튼 연결
  // TODO 장바구니, 구매하기 버튼 연결



##### close #162
