### PR TITLE
[#236] 하위 카테고리페이지 무한스크롤 api 연결

### DIFF
--- a/src/components/button/sidebar/sidebarTab.tsx
+++ b/src/components/button/sidebar/sidebarTab.tsx
@@ -23,7 +23,7 @@ function SidebarTab({ pageName}: SidebarProps) {
         href={`/${locatedCategory.mainId === 0 ? 'domestic' : 'foreign'}`}>
         전체보기
       </Link>
-      {(categoryList) && categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"].map((el, ind) => {
+      {(categoryList) && (categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"] ?? []).map((el, ind) => {
         return (
           <Link
               onClick={() => {

--- a/src/components/button/sidebar/sidebarTabController.tsx
+++ b/src/components/button/sidebar/sidebarTabController.tsx
@@ -22,7 +22,7 @@ function SidebarTabController({pageName}: SidebarProps) {
   const { env } = useCarouselEnv();
   const [categoryList,] = useAtom(CategoryListAtom);
   const [locatedCategory] = useAtom(LocatedCategoryAtom);
-  const locatedTitle = locatedCategory.subId ? categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"][locatedCategory.subId-1].subName : '전체보기';
+  const locatedTitle = (locatedCategory.subId && categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"] && categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"].length > 0)? categoryList[locatedCategory.mainId === 0 ? "domestic" : "foreign"][locatedCategory.subId-1].subName : '전체보기';
 
   const handleClick = () => setShowOptions(!showOptions);
 

--- a/src/components/container/categoryBookList/mainCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/mainCategoryBookList.tsx
@@ -37,7 +37,11 @@ function MainCategoryBookList() {
     selectFunc: (data) => {
       return (data.pages ?? []).flatMap(page => {
         if (page?.data?.books.length < 2) return page?.data?.books;
-        return page?.data?.books.slice(0, page.data.books.length - 1)
+        if (hasNextPage) { 
+          return page?.data?.books.slice(0, page.data.books.length - 1)
+        } else {
+          return page?.data?.books.slice(0, page.data.books.length);
+        }
       })
     },
   })

--- a/src/components/container/categoryBookList/subCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/subCategoryBookList.tsx
@@ -1,33 +1,62 @@
 import { useState } from "react";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 
+import { getBook } from "@/api/book";
 import PreviewBookInfo from "@/components/book/previewBookInfo/previewBookInfo";
 import DropDown from "@/components/dropDown/dropDown";
-import { BOOK_OLDER_STANDARD } from "src/constants/orderList";
+import SkeletonPreviewBookInfo from "@/components/skeleton/previewBookInfo/skeleton";
 import useCarouselEnv from "@/hooks/useCarouselEnv";
 import useGetCategoryId from "@/hooks/useGetCategoryId";
+import useInfinite from "@/hooks/useInfinite";
+import useCustomInfiniteQuery from "@/hooks/useCustomInfiniteQuery";
 import { LocatedCategoryAtom } from "@/store/state";
 
-import TestImage1 from '@/public/images/SampleBookCover1.jpeg';
-import { DomesticBookList } from "@/pages/api/mock/domesticBookListMock";
+import { BOOK_OLDER_STANDARD } from "src/constants/orderList";
+
+const CURRENT_ORDER = {
+  sort: "VIEW",
+  ascending: false,
+}
 
 function SubCategoryBookList() {
-  const [selectedOrder, setSelectedOrder] = useState("조회순");
   const { env } = useCarouselEnv();
   const [locatedCategory,] = useAtom(LocatedCategoryAtom);
+  const [selectedOrder, setSelectedOrder] = useState("조회순");
+  const [currentOrder, setCurrentOrder] = useState(CURRENT_ORDER);
+  const [apiRef, isIntersecting] = useInfinite();
   const searchId = useGetCategoryId(locatedCategory.mainId, locatedCategory.subId ?? 0);
-  // const { data, isLoading, isError } = useQuery({
-  //   queryKey: [searchId, "sub-category-page-books"],
-  // }) 
+
+  const { data, isFetchingNextPage, hasNextPage } = useCustomInfiniteQuery({
+    endpoint: `${searchId}/sub`,
+    queryKey: [selectedOrder, String(searchId), "main-category-book-list"],
+    queryFunc: getBook,
+    cursorName: "bookId",
+    sort: currentOrder.sort,
+    initialCursorId: 0,
+    ascending: currentOrder.ascending,
+    refetchTrigger: (isIntersecting),
+    getNextPageParamsFunc:  (lastPage) =>  lastPage?.data.books.length <= 1 || lastPage?.data.cursorId <= 0 ? undefined : lastPage.data.books[lastPage.data.books.length - 1].bookId,
+    selectFunc: (data) => {
+      return (data.pages ?? []).flatMap(page => {
+        if (page?.data?.books.length < 2) return page?.data?.books;
+        return page?.data?.books.slice(0, page.data.books.length - 1)
+      })
+    },
+  })
 
   const onSelectedOrder = (menu: string) => {
     setSelectedOrder(menu);
+    if (menu === "조회순") setCurrentOrder((prev) => { return { ...prev, sort: "VIEW", ascending: false } });
+    if (menu === "신상품순") setCurrentOrder((prev) => { return { ...prev, sort: "NEWEST", ascending: false } });
+    if (menu === "별점순") setCurrentOrder((prev) => { return { ...prev, sort: "STAR", ascending: false } });
+    if (menu === "리뷰 많은순") setCurrentOrder((prev) => { return { ...prev, sort: "REVIEW", ascending: false } });
+    if (menu === "낮은 가격순") setCurrentOrder((prev) => { return { ...prev, sort: "PRICE", ascending: true } });
+    if (menu === "높은 가격순") setCurrentOrder((prev) => { return { ...prev, sort: "PRICE", ascending: false } });
   }
 
   return (
-      <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
+      <article className="flex flex-col gap-50 relative h-fit mobile:gap-20 tablet:gap-40 pb-30">
         <div className="flex items-center justify-between">
           <h1 className="text-20 text-black">모든 도서</h1>
           <div className="z-20">
@@ -36,14 +65,14 @@ function SubCategoryBookList() {
         </div>
       
         <div
-          className="h-[708px] w-[895px] mobile:h-[1735px] mobile:w-[330px]
-          tablet:h-[1464px] tablet:w-[511px] grid grid-flow-row grid-cols-5 tablet:grid-cols-3 mobile:grid-cols-2 auto-rows-auto gap-x-20 gap-y-40 mobile:gap-y-0 ">
-        {DomesticBookList.map((book) => {
+          className="h-fit w-[895px] mobile:w-[330px]
+           tablet:w-[511px] grid grid-flow-row grid-cols-5 tablet:grid-cols-3 mobile:grid-cols-2 auto-rows-auto gap-x-20 gap-y-40 mobile:gap-y-0 ">
+        {data?.map((book) => {
           return (
             <Link href={`/bookdetail/${book.bookId}`} key={book.bookId} className="w-fit h-fit">
             <PreviewBookInfo
-              image={book.imageUrl ?? TestImage1}
-              title={book.title}
+              image={book.bookImgUrl}
+              title={book.bookTitle}
               authorList={book.authors}
               price={book.price}
               size={env === "desktop"?"md" : "lg"}
@@ -52,7 +81,18 @@ function SubCategoryBookList() {
               )
         })}
         
-          </div>
+      </div>
+      {(isFetchingNextPage || isIntersecting) && 
+        <div
+          className="min-h-400 w-[895px] mobile:w-[330px]
+           tablet:w-[511px] grid grid-flow-row grid-cols-5 tablet:grid-cols-3 mobile:grid-cols-2 auto-rows-auto gap-x-20 gap-y-40 mobile:gap-y-0 ">          {[0, 1, 2].map(el => {
+            return <SkeletonPreviewBookInfo key={el} />
+          })
+        }
+        </div>
+      }
+        <div className={`h-5 w-300 ${hasNextPage ? "block" : "hidden"}`} ref={apiRef} ></div>
+
     </article>
   )}
 

--- a/src/components/container/categoryBookList/subCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/subCategoryBookList.tsx
@@ -40,7 +40,11 @@ function SubCategoryBookList() {
     selectFunc: (data) => {
       return (data.pages ?? []).flatMap(page => {
         if (page?.data?.books.length < 2) return page?.data?.books;
-        return page?.data?.books.slice(0, page.data.books.length - 1)
+        if (hasNextPage) { 
+          return page?.data?.books.slice(0, page.data.books.length - 1)
+        } else {
+          return page?.data?.books.slice(0, page.data.books.length);
+        }
       })
     },
   })

--- a/src/components/container/categoryBookList/subCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/subCategoryBookList.tsx
@@ -25,7 +25,7 @@ function SubCategoryBookList() {
   const [selectedOrder, setSelectedOrder] = useState("조회순");
   const [currentOrder, setCurrentOrder] = useState(CURRENT_ORDER);
   const [apiRef, isIntersecting] = useInfinite();
-  const searchId = useGetCategoryId(locatedCategory.mainId, locatedCategory.subId ?? 0);
+  const searchId = useGetCategoryId(locatedCategory.mainId, locatedCategory.subId as number);
 
   const { data, isFetchingNextPage, hasNextPage } = useCustomInfiniteQuery({
     endpoint: `${searchId}/sub`,

--- a/src/hooks/useGetCategoryId.ts
+++ b/src/hooks/useGetCategoryId.ts
@@ -6,6 +6,7 @@ import { CategoryListAtom } from "@/store/state"
 
 function useGetCategoryId(mainId: number, subId: number) {
   const [categoryList,] = useAtom(CategoryListAtom);
+  if (!subId || categoryList.domestic.length < 1) return;
   const requiredCategory = categoryList[mainId === 0 ? "domestic" : "foreign"][subId - 1 >= 0 ? subId-1 : 0];
   const requiredId = requiredCategory.categoryId;
   return requiredId as number;

--- a/src/hooks/useGetCategoryId.ts
+++ b/src/hooks/useGetCategoryId.ts
@@ -7,8 +7,8 @@ import { CategoryListAtom } from "@/store/state"
 function useGetCategoryId(mainId: number, subId: number) {
   const [categoryList,] = useAtom(CategoryListAtom);
   const requiredCategory = categoryList[mainId === 0 ? "domestic" : "foreign"][subId - 1 >= 0 ? subId-1 : 0];
-  const requiredId = requiredCategory?.categoryId;
-  return requiredId;
+  const requiredId = requiredCategory.categoryId;
+  return requiredId as number;
 }
 
 export default useGetCategoryId

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -4,6 +4,7 @@ import EventSection from '@/components/container/eventSection/eventSection';
 import CategoryCarousel from '@/components/carousel/categoryCarousel';
 import { carouselMockData } from '@/pages/api/mock/carouselMock';
 import { responsive } from '@/utils/checkResponsiveEnv';
+import SubCategoryBookList from '@/components/container/categoryBookList/subCategoryBookList';
 
 function CategoryPage() {
   return (
@@ -25,6 +26,7 @@ function CategoryPage() {
         </article>        
         <Spacing height={[120, 80, 80]} />
 
+        <SubCategoryBookList />
       </SidebarLayout>
   );
 }

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -4,6 +4,7 @@ import EventSection from '@/components/container/eventSection/eventSection';
 import CategoryCarousel from '@/components/carousel/categoryCarousel';
 import { carouselMockData } from '@/pages/api/mock/carouselMock';
 import { responsive } from '@/utils/checkResponsiveEnv';
+import SubCategoryBookList from '@/components/container/categoryBookList/subCategoryBookList';
 
 function CategoryPage() {
   return (
@@ -23,8 +24,9 @@ function CategoryPage() {
             className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
             tablet:w-[511px]"></div>
         </article>        
-        <Spacing height={[120, 80, 80]} />
-
+      <Spacing height={[120, 80, 80]} />
+      
+        <SubCategoryBookList />
       </SidebarLayout>
   );
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -9,7 +9,7 @@ export const pointVisibleAtom = atom(true);
 export const CurrentPageStateAtom = atom(1);
 
 // 맨 처음 카테고리 리스트 데이터를 받아와 저장하는 전역상태
-export const CategoryListAtom = atom<CategoryAtomType>({domestic: [], foreign: []});
+export const CategoryListAtom = atom<CategoryAtomType>({"domestic": [], "foreign": []});
 
 // 내가 현재 위치한 카테고리 mainId, subId를 알려주는 전역상태
 export const LocatedCategoryAtom = atom<CategoryType>({


### PR DESCRIPTION
## 구현사항

디자인적으로 바뀐 건 하나도 없습니다!! 로직도 메인 카테고리페이지와 다를 게 없습니다. 

1. 하위 카테고리 페이지 뭐 국내 소설, 외국 과학.. 등등에도 무한 스크롤을 연결했습니다.
2. 책 리스트를 받을 때 맨 마지막 책 한권이 잘리는 문제가 있어 수정했습니다. 

-[] 구현한 내용 및 설명

## 사용방법

- [ ] 카테고리 페이지로 들어가서 스크롤 쭈욱 내리면 바로 확인 가능합니다!!!

## 스크린샷

카테고리 별, sort 별로 데이터 잘 나옵니다!!

![Honeycam 2024-02-14 20-09-39](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/d5e93530-984c-4588-918e-260924d6bed3)


##### close #236
