### PR TITLE
[#262] 베스트/신간페이지 카테고리 내 도서가 없을때 UI 적용 + 토큰 환경변수적용

### DIFF
--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -17,6 +17,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const [likeCount, setIsLikeCount] = useState(book.bookmarkCount);
   const router = useRouter();
   const formattedDate = formatDate(book.publishedDate);
+  const token = process.env.NEXT_PUBLIC_ACCESS_TOKEN as string;
 
   const handleLikeClick = () => {
     setIsLiked(!isLiked);
@@ -28,8 +29,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     try {
       await postBasket({
         bookId: book.bookId,
-        token:
-          'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBQ0NFU1NfVE9LRU4iLCJpYXQiOjE3MDc5NzI1MjEsImV4cCI6MTcwODA1ODkyMSwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIn0.cPnOU9qU2phcdWAQiiYc-kmzjS4f_o-MMLlAhzyTv-6G31Q7AcemGNg2bhaRWaXXbkBu-ok1ZFSC6SHpFwn9ww',
+        token: token,
       });
       notify({
         type: 'success',

--- a/src/components/card/bookOverviewCard/bookOverViewCardList.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCardList.tsx
@@ -1,5 +1,6 @@
 import BookOverviewCard from './bookOverViewCard';
 import { BookData } from '@/types/api/book';
+import BookOverviewEmptyCard from './bookOverviewEmptyCard';
 
 interface BookOverViewCardListProps {
   bookData: BookData[];
@@ -11,11 +12,15 @@ function BookOverViewCardList({ title, bookData }: BookOverViewCardListProps) {
     <div className="flex flex-col gap-40 pb-40 text-black">
       <h1 className="text-20 font-bold">{title}</h1>
       <div className="flex flex-col gap-20 mobile:gap-10">
-        {bookData.map((data, index) => (
-          <div key={data?.bookId}>
-            <BookOverviewCard book={data} rank={index + 1} />
-          </div>
-        ))}
+        {bookData.length !== 0 ? (
+          bookData.map((data, index) => (
+            <div key={data?.bookId}>
+              <BookOverviewCard book={data} rank={index + 1} />
+            </div>
+          ))
+        ) : (
+          <BookOverviewEmptyCard />
+        )}
       </div>
     </div>
   );

--- a/src/components/card/bookOverviewCard/bookOverviewEmptyCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverviewEmptyCard.tsx
@@ -1,0 +1,11 @@
+function BookOverviewEmptyCard() {
+  return (
+    <div
+      className="
+        p-120 text-center mobile:p-30">
+      이 카테고리에 등록된 도서가 없어요!
+    </div>
+  );
+}
+
+export default BookOverviewEmptyCard;

--- a/src/pages/domestic/[category]/bestseller/index.tsx
+++ b/src/pages/domestic/[category]/bestseller/index.tsx
@@ -3,11 +3,9 @@ import BookOverViewCardList from '@/components/card/bookOverviewCard/bookOverVie
 import Header from '@/components/header';
 import BestSellerPageLayout from '@/components/layout/bestSellerLayout';
 import Sidebar from '@/components/sidebar/sidebar';
-
 import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
 import { useInitialBestNewestParams } from '@/hooks/useInitialParams';
 import { BookData } from '@/types/api/book';
-import { useAtom } from 'jotai';
 
 const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'BESTSELLER' });
 


### PR DESCRIPTION
## 구현사항

- 베스트/신간 페이지 내에 카테고리 내 도서가 없을 때 보여줄 BookOverviewEmptyCard를 만들었어요
- 장바구니 담기 api 요청시 보낼 token을 환경변수에 저장했어용

## 사용방법

### BookOverviewEmptyCard
![스크린샷 2024-02-15 오후 9 30 33](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/043e8c5d-a70b-46e8-830b-1a504685461f)
배열 내부가 비었을떄 보여주도록 했어용
***
### token 환경변수에 저장
각자의 로컬에 .env.local  파일에 아래처럼 NEXT_PUBLIC_ACCESS_TOKEN 값으로 테스트에 사용할 토큰값을 넣어주세용

![스크린샷 2024-02-15 오후 9 32 30](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/55f3793a-a424-4d51-8a92-033e6fba9e24)



BookOverviewCard 컴포넌트 내부에서 아래와같이 사용해주세용
![스크린샷 2024-02-15 오후 9 33 07](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/e08782c3-6f9b-4ff3-af18-862719b1cb66)

버셀 환경변수에는 제 토큰값을 넣어두었어용
로컬 환경에서는 각자의  .env.local 파일에 토큰값을 변경하셔도 문제없습니당!(gpt피셜)
![스크린샷 2024-02-15 오후 9 34 05](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/55ba5660-35ab-4d65-9c2f-ecfda1d4352e)


혹시 이 과정이 귀찮으시면 테스트할때 

![스크린샷 2024-02-15 오후 9 35 30](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/117fdfd0-ae97-4931-8960-13b1de206701)

token: token << 이부분에 그냥 토큰 스트링값 때려넣으셔도 됩니당
#### 하쥐만 앞으로 토큰쓸일이 많을것 같아서 환경변수에 저장해두시면 더 편할것 같긴합니닷!


## 스크린샷


<img width="492" alt="스크린샷 2024-02-15 오후 9 28 49" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/d05728a6-bee1-4114-8e66-324b60097665">

##### close #262 
