### PR TITLE
[#265,#266] 메인페이지 신간 도서 섹션, 베스트셀러 섹션 api 연결

### DIFF
--- a/src/components/book/previewBookInfo/authors.tsx
+++ b/src/components/book/previewBookInfo/authors.tsx
@@ -6,7 +6,7 @@ interface BookAuthorsProps {
 function BookAuthors({ alignCenter, authorList }: BookAuthorsProps) {
   return (
     <div
-      className={`text-gray-3 text-14 truncate ${alignCenter ? 'text-center' : ''}`}>
+      className={`truncate text-14 text-gray-3 ${alignCenter ? 'text-center' : ''}`}>
       {authorList.join(', ')}
     </div>
   );

--- a/src/components/book/previewBookInfo/previewBookInfo.tsx
+++ b/src/components/book/previewBookInfo/previewBookInfo.tsx
@@ -11,6 +11,7 @@ import BookTitle from './title';
 import BookAuthors from './authors';
 import BookPrice from './price';
 import BookCategory from './category';
+import Link from 'next/link';
 
 function PreviewBookInfo({
   image,
@@ -22,6 +23,7 @@ function PreviewBookInfo({
   price,
   category,
   itemsStart,
+  bookId,
 }: PreviewBookInfoProps) {
   const STYLE = {
     img: `${IMAGE_SIZE[size].pc} ${IMAGE_SIZE[size].tablet} ${IMAGE_SIZE[size].mobile}`,
@@ -40,58 +42,60 @@ function PreviewBookInfo({
   }
 
   return (
-    <div className={`relative flex flex-col ${STYLE.width}`}>
-      <div
-        className={`${STYLE.img} flex flex-col ${itemsStart ? 'justify-start' : 'relative justify-end'}
+    <Link href={`/bookdetail/${bookId}`}>
+      <div className={`relative flex flex-col ${STYLE.width}`}>
+        <div
+          className={`${STYLE.img} flex flex-col ${itemsStart ? 'justify-start' : 'relative justify-end'}
           overflow-hidden`}>
-        <div>
-          <Image
-            src={image || DefaultImage}
-            alt="책 미리보기 이미지"
-            layout="responsive"
-            width={0}
-            height={0}
-          />
-          {ranking && (
-            <div
-              className={`absolute ${itemsStart ? 'left-17 top-[-2px]' : ' bottom-[-2px] right-0'}`}>
-              <Image
-                src={
-                  itemsStart
-                    ? ranking > 10
-                      ? BookLabelGrayIcon
-                      : BookLabelGreenIcon
-                    : ranking > 10
-                      ? BookLabelBottomGrayIcon
-                      : BookLabelBottomIcon
-                }
-                alt="순위라벨 이미지"
-              />
-              <span
-                className={`absolute text-[13px] font-bold text-white ${itemsStart ? 'left-10 top-5' : 'bottom-5 right-9'} ${
-                  ranking > 99
-                    ? itemsStart
-                      ? 'left-[2px] tracking-[-0.5px]'
-                      : 'left-17 tracking-[-0.5px]'
-                    : ranking > 9
+          <div>
+            <Image
+              src={image || DefaultImage}
+              alt="책 미리보기 이미지"
+              layout="responsive"
+              width={0}
+              height={0}
+            />
+            {ranking && (
+              <div
+                className={`absolute ${itemsStart ? 'left-17 top-[-2px]' : ' bottom-[-2px] right-0'}`}>
+                <Image
+                  src={
+                    itemsStart
+                      ? ranking > 10
+                        ? BookLabelGrayIcon
+                        : BookLabelGreenIcon
+                      : ranking > 10
+                        ? BookLabelBottomGrayIcon
+                        : BookLabelBottomIcon
+                  }
+                  alt="순위라벨 이미지"
+                />
+                <span
+                  className={`absolute text-[13px] font-bold text-white ${itemsStart ? 'left-10 top-5' : 'bottom-5 right-9'} ${
+                    ranking > 99
                       ? itemsStart
-                        ? 'left-6 tracking-[-0.6px]'
-                        : 'left-20 tracking-[-0.6px]'
-                      : ''
-                }`}>
-                {ranking}
-              </span>
-            </div>
-          )}
+                        ? 'left-[2px] tracking-[-0.5px]'
+                        : 'left-17 tracking-[-0.5px]'
+                      : ranking > 9
+                        ? itemsStart
+                          ? 'left-6 tracking-[-0.6px]'
+                          : 'left-20 tracking-[-0.6px]'
+                        : ''
+                  }`}>
+                  {ranking}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
+        {title && <BookTitle title={title} alignCenter={alignCenter} />}
+        {authorList && (
+          <BookAuthors authorList={authorList} alignCenter={alignCenter} />
+        )}
+        {category && <BookCategory category={category} />}
+        {price && <BookPrice price={price} />}
       </div>
-      {title && <BookTitle title={title} alignCenter={alignCenter} />}
-      {authorList && (
-        <BookAuthors authorList={authorList} alignCenter={alignCenter} />
-      )}
-      {category && <BookCategory category={category} />}
-      {price && <BookPrice price={price} />}
-    </div>
+    </Link>
   );
 }
 export default PreviewBookInfo;

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -64,6 +64,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
             image={book.bookImgUrl}
             ranking={rank}
             itemsStart
+            bookId={book.bookId}
           />
         </Link>
 

--- a/src/components/card/bookPaymentCard/bookPaymentCard.tsx
+++ b/src/components/card/bookPaymentCard/bookPaymentCard.tsx
@@ -18,7 +18,12 @@ function BookPaymentCard({ book, order }: BookOrderType) {
           role="book-img"
           href={`bookdetail/${book.productId}`}
           className="h-170 bg-white mobile:h-134 mobile:min-w-93">
-          <PreviewBookInfo size="sm" image={book.imageUrl} itemsStart />
+          <PreviewBookInfo
+            size="sm"
+            image={book.imageUrl}
+            itemsStart
+            bookId={book.productId}
+          />
         </Link>
 
         <div

--- a/src/components/card/todayBestBookCard/TodayBestBookCard.tsx
+++ b/src/components/card/todayBestBookCard/TodayBestBookCard.tsx
@@ -29,7 +29,15 @@ const STYLE = {
   img: `${SIZE.desktop.img} ${SIZE.mobile.img}`,
 };
 
-function TodayBestBook({ bookId, bookImgUrl, bookTitle, price, authors, averageRating, categories }: BookData) {
+function TodayBestBook({
+  bookId,
+  bookImgUrl,
+  bookTitle,
+  price,
+  authors,
+  averageRating,
+  categories,
+}: BookData) {
   return (
     <div
       role="container"
@@ -42,17 +50,35 @@ function TodayBestBook({ bookId, bookImgUrl, bookTitle, price, authors, averageR
           role="img-section"
           className={`flex-center relative bg-white ${STYLE.img}`}>
           {bookImgUrl ? (
-          <PreviewBookInfo size='sm' image={bookImgUrl} itemsStart/>
+            <PreviewBookInfo
+              size="sm"
+              image={bookImgUrl}
+              itemsStart
+              bookId={bookId}
+            />
           ) : (
             <div className={`bg-gray-1 ${STYLE.img}`}></div>
           )}
         </div>
         <div className="flex flex-col items-start justify-start gap-4">
-          <BookTitle isBold fontSize={15} title={bookTitle} classNames='line-clamp-2 mobile:line-clamp-1' />
-          <BookAuthor authorList={authors} fontSize={14} classNames='line-clamp-1 mobile:hidden'/>
+          <BookTitle
+            isBold
+            fontSize={15}
+            title={bookTitle}
+            classNames="line-clamp-2 mobile:line-clamp-1"
+          />
+          <BookAuthor
+            authorList={authors}
+            fontSize={14}
+            classNames="line-clamp-1 mobile:hidden"
+          />
           <BookRating rating={averageRating} />
-          <BookCategory categories={categories} fontSize={13} classNames='line-clamp-2'/>
-          <BookPrice price={price}  fontSize={14} isBold hasUnit/>
+          <BookCategory
+            categories={categories}
+            fontSize={13}
+            classNames="line-clamp-2"
+          />
+          <BookPrice price={price} fontSize={14} isBold hasUnit />
         </div>
       </Link>
     </div>

--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -118,11 +118,12 @@ function Carousel({ data, responsive }: CarouselProps) {
               <CarouselCard
                 imageUrl={item.bookImgUrl as string}
                 title={item.bookTitle}
-                authorname={item.authors}
+                authorname={item.authors[1]}
                 key={index}
                 imageSize={responsive[env].imageSize}
                 marginRight={CARD_MARGIN_VALUE}
                 size="md"
+                bookId={item.bookId}
               />
             ))}
           </div>

--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -68,7 +68,7 @@ function Carousel({ data, responsive }: CarouselProps) {
       <div
         className="mx-60 mb-40 flex items-center justify-between mobile:mx-15 mobile:mb-20
           tablet:mx-40">
-        <span className="text-20 text-black">신간도서</span>
+        <span className="text-20 font-bold text-black">신간도서</span>
         <Link href="/domestic/newest" className="text-16 text-green">
           더보기
         </Link>
@@ -118,7 +118,7 @@ function Carousel({ data, responsive }: CarouselProps) {
               <CarouselCard
                 imageUrl={item.bookImgUrl as string}
                 title={item.bookTitle}
-                authorname={item.authors[1]}
+                authorname={item.authors}
                 key={index}
                 imageSize={responsive[env].imageSize}
                 marginRight={CARD_MARGIN_VALUE}

--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -118,7 +118,7 @@ function Carousel({ data, responsive }: CarouselProps) {
               <CarouselCard
                 imageUrl={item.bookImgUrl as string}
                 title={item.bookTitle}
-                authorname={item.authors}
+                authorList={item.authors}
                 key={index}
                 imageSize={responsive[env].imageSize}
                 marginRight={CARD_MARGIN_VALUE}

--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -1,6 +1,7 @@
 import CarouselCard from '@/components/carousel/carouselCard';
 import useCarouselEnv from '@/hooks/useCarouselEnv';
-import { NewBook, ResponSive } from '@/types/carouselType';
+import { ResponSive } from '@/types/carouselType';
+import { BookData } from '@/types/api/book';
 import { inrange } from '@/utils/inrange';
 import registDragEvent from '@/utils/registerDragEvent';
 import Image from 'next/image';
@@ -9,7 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 const CARD_MARGIN_VALUE = 20;
 
 type CarouselProps = {
-  data: NewBook[];
+  data: BookData[];
   responsive: ResponSive;
 };
 
@@ -115,8 +116,10 @@ function Carousel({ data, responsive }: CarouselProps) {
             })}>
             {data.map((item, index) => (
               <CarouselCard
+                imageUrl={item.bookImgUrl as string}
+                title={item.bookTitle}
+                authorname={item.authors}
                 key={index}
-                {...item}
                 imageSize={responsive[env].imageSize}
                 marginRight={CARD_MARGIN_VALUE}
                 size="md"

--- a/src/components/carousel/carouselCard.tsx
+++ b/src/components/carousel/carouselCard.tsx
@@ -17,10 +17,14 @@ function CarouselCard(props: CarouselCardProps) {
   return (
     <div>
       <div
-        className={`text-white relative select-none`}
+        className={`relative select-none text-white`}
         style={{ width, marginRight }}>
-        <PreviewBookInfo size={size} title={title} authorList={[authorname]} />
-
+        <PreviewBookInfo
+          image={imageUrl}
+          size={size}
+          title={title}
+          authorList={[authorname]}
+        />
       </div>
     </div>
   );

--- a/src/components/carousel/carouselCard.tsx
+++ b/src/components/carousel/carouselCard.tsx
@@ -6,7 +6,7 @@ export type CarouselCardProps = {
   size: 'sm' | 'md' | 'lg';
   imageUrl: string;
   title: string;
-  authorname: string;
+  authorname: string[];
   imageSize: ImageSize;
   marginRight: number;
   bookId?: number;
@@ -25,7 +25,7 @@ function CarouselCard(props: CarouselCardProps) {
           image={imageUrl}
           size={size}
           title={title}
-          authorList={[authorname]}
+          authorList={authorname}
           bookId={bookId}
         />
       </div>

--- a/src/components/carousel/carouselCard.tsx
+++ b/src/components/carousel/carouselCard.tsx
@@ -6,16 +6,17 @@ export type CarouselCardProps = {
   size: 'sm' | 'md' | 'lg';
   imageUrl: string;
   title: string;
-  authorname: string[];
+  authorList: string[];
   imageSize: ImageSize;
   marginRight: number;
   bookId?: number;
 };
 
 function CarouselCard(props: CarouselCardProps) {
-  const { imageUrl, bookId, title, authorname, imageSize, marginRight, size } =
+  const { imageUrl, bookId, title, authorList, imageSize, marginRight, size } =
     props;
   const { width } = imageSize;
+
   return (
     <div>
       <div
@@ -25,7 +26,7 @@ function CarouselCard(props: CarouselCardProps) {
           image={imageUrl}
           size={size}
           title={title}
-          authorList={authorname}
+          authorList={authorList}
           bookId={bookId}
         />
       </div>

--- a/src/components/carousel/carouselCard.tsx
+++ b/src/components/carousel/carouselCard.tsx
@@ -12,9 +12,15 @@ export type CarouselCardProps = {
   bookId?: number;
 };
 
-function CarouselCard(props: CarouselCardProps) {
-  const { imageUrl, bookId, title, authorList, imageSize, marginRight, size } =
-    props;
+function CarouselCard({
+  size,
+  imageUrl,
+  title,
+  authorList,
+  imageSize,
+  marginRight,
+  bookId,
+}: CarouselCardProps) {
   const { width } = imageSize;
 
   return (

--- a/src/components/carousel/carouselCard.tsx
+++ b/src/components/carousel/carouselCard.tsx
@@ -9,10 +9,12 @@ export type CarouselCardProps = {
   authorname: string;
   imageSize: ImageSize;
   marginRight: number;
+  bookId?: number;
 };
 
 function CarouselCard(props: CarouselCardProps) {
-  const { imageUrl, title, authorname, imageSize, marginRight, size } = props;
+  const { imageUrl, bookId, title, authorname, imageSize, marginRight, size } =
+    props;
   const { width } = imageSize;
   return (
     <div>
@@ -24,6 +26,7 @@ function CarouselCard(props: CarouselCardProps) {
           size={size}
           title={title}
           authorList={[authorname]}
+          bookId={bookId}
         />
       </div>
     </div>

--- a/src/components/carousel/categoryCarousel.tsx
+++ b/src/components/carousel/categoryCarousel.tsx
@@ -145,11 +145,13 @@ function CategoryCarousel({ data, responsive }: CarouselProps) {
             })}>
             {data.map((item, index) => (
               <CarouselCard
+                authorList={item.authorList}
                 key={index}
-                {...item}
                 imageSize={responsive[env].imageSize}
                 marginRight={calcMarginValue(env)}
                 size="sm"
+                imageUrl={item.imageUrl}
+                title={item.title}
               />
             ))}
           </div>

--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -33,6 +33,7 @@ function BestSellerSection() {
             image={book.bookImgUrl}
             authorList={book.authors}
             ranking={index + 1}
+            bookId={book.bookId}
           />
         ))}
       </div>
@@ -46,6 +47,7 @@ function BestSellerSection() {
             image={book.bookImgUrl}
             authorList={book.authors}
             ranking={index + 1}
+            bookId={book.bookId}
           />
         ))}
       </div>

--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -1,8 +1,19 @@
 import Link from 'next/link';
-import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
 import PreviewBookInfo from '@/components/book/previewBookInfo/previewBookInfo';
+import { useGetBook } from '@/api/book';
+import { BookData } from '@/types/api/book';
 
 function BestSellerSection() {
+  const { data, isLoading, isError } = useGetBook({
+    endpoint: '0/main',
+    params: {
+      bookId: '0',
+      limit: '10',
+      sort: 'BESTSELLER',
+      ascending: false,
+    },
+  });
+  const bookList: Array<BookData> = data ? data.data.books : [];
   return (
     <div
       className="flex-col mobile:mx-15 mobile:my-80 mobile:w-330 tablet:mx-40 tablet:my-120
@@ -14,26 +25,27 @@ function BestSellerSection() {
         </Link>
       </div>
       <div className="flex-center flex flex-wrap gap-x-10 gap-y-62 tablet:hidden pc:gap-x-30">
-        {bookOverviewsMock.map((book, index) => (
+        {bookList.map((book, index) => (
           <PreviewBookInfo
-            key={book.book.bookId}
+            key={book.bookId}
             size={'lg'}
-            title={book.book.bookTitle}
-            image={book.book.bookImgUrl}
-            authorList={book.book.authors}
+            title={book.bookTitle}
+            image={book.bookImgUrl}
+            authorList={book.authors}
             ranking={index + 1}
           />
         ))}
       </div>
 
       <div className="flex w-full flex-wrap justify-start gap-x-20 gap-y-62 mobile:hidden pc:hidden">
-        {bookOverviewsMock.map((book, index) => (
+        {bookList.map((book, index) => (
           <PreviewBookInfo
-            key={book.book.bookId}
+            key={book.bookId}
             size={'sm'}
-            title={book.book.bookTitle}
-            image={book.book.bookImgUrl}
-            authorList={book.book.authors}
+            title={book.bookTitle}
+            image={book.bookImgUrl}
+            authorList={book.authors}
+            ranking={index + 1}
           />
         ))}
       </div>

--- a/src/components/container/todayBestSection/todayBestSection.tsx
+++ b/src/components/container/todayBestSection/todayBestSection.tsx
@@ -36,14 +36,14 @@ const STYLE = {
 
 function TodayBestSection() {
   const { data, isLoading, isError } = useGetBook({
-    endpoint: "0/main",
+    endpoint: '0/main',
     params: {
-      bookId: "0",
-      limit: "6",
-      sort: "POPULATION",
+      bookId: '0',
+      limit: '6',
+      sort: 'POPULATION',
       ascending: false,
-    }
-  })
+    },
+  });
   const bookList: Array<BookData> = data ? data.data.books : [];
   const { dynamicWid } = useWindowInnerWidth();
 

--- a/src/pages/api/mock/carouselMock.ts
+++ b/src/pages/api/mock/carouselMock.ts
@@ -3,66 +3,66 @@ export const carouselMockData = [
     imageUrl:
       'https://cdn.pixabay.com/photo/2024/01/21/18/46/succulent-8523664_1280.jpg',
     title: '책1',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2022/11/08/06/05/read-7577787_1280.jpg',
     title: '책2',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2021/01/21/15/54/books-5937716_1280.jpg',
     title: '책3',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2024/01/16/19/40/trees-8512979_1280.jpg',
     title: '책4',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2024/01/13/00/46/raccoon-8504925_1280.png',
     title: '책5',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책6',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책7',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책8',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책9',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '마지막이다',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '마지막2222222',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
 ];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,23 @@ import Carousel from '@/components/carousel/carousel';
 import { carouselMockData } from './api/mock/carouselMock';
 import { responsive } from '@/utils/checkResponsiveEnv';
 import TodayBestSection from '@/components/container/todayBestSection/todayBestSection';
+import { useGetBook } from '@/api/book';
+import { BookData } from '@/types/api/book';
+import { NewBook } from '@/types/carouselType';
 function Home() {
+  const { data, isLoading, isError } = useGetBook({
+    endpoint: '0/main',
+    params: {
+      bookId: '0',
+      limit: '6',
+      sort: 'NEWEST',
+      ascending: false,
+    },
+  });
+
+  const bookList: Array<BookData> = data ? data.data.books : [];
+  console.log('booklist: ' + bookList);
+  console.log('bookdata: ' + data);
   return (
     <>
       <div
@@ -24,7 +40,7 @@ function Home() {
       </div>
       <CustomSection isLoggedIn={true} isGenreSelected={true} />
       <div className="mt-80 mobile:mb-80 tablet:mb-120 pc:mb-140">
-        <Carousel data={carouselMockData} responsive={responsive} />
+        <Carousel data={bookList} responsive={responsive} />
       </div>
 
       <TodayBestSection />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,12 +3,10 @@ import MainLayout from '@/components/layout/mainLayout';
 import CustomSection from '@/components/container/customSection/customSection';
 import BestSellerSection from '@/components/container/bestsellerSection/bestsellerSection';
 import Carousel from '@/components/carousel/carousel';
-import { carouselMockData } from './api/mock/carouselMock';
 import { responsive } from '@/utils/checkResponsiveEnv';
 import TodayBestSection from '@/components/container/todayBestSection/todayBestSection';
 import { useGetBook } from '@/api/book';
 import { BookData } from '@/types/api/book';
-import { NewBook } from '@/types/carouselType';
 function Home() {
   const { data, isLoading, isError } = useGetBook({
     endpoint: '0/main',
@@ -21,8 +19,6 @@ function Home() {
   });
 
   const bookList: Array<BookData> = data ? data.data.books : [];
-  console.log('booklist: ' + bookList);
-  console.log('bookdata: ' + data);
   return (
     <>
       <div

--- a/src/pages/test/footer/index.tsx
+++ b/src/pages/test/footer/index.tsx
@@ -2,11 +2,8 @@ import { ReactElement } from 'react';
 import MainLayout from '@/components/layout/mainLayout';
 import CustomSection from '@/components/container/customSection/customSection';
 import BestSellerSection from '@/components/container/bestsellerSection/bestsellerSection';
-import Carousel from '@/components/carousel/carousel';
-
-import { responsive } from '@/utils/checkResponsiveEnv';
 import TodayBestSection from '@/components/container/todayBestSection/todayBestSection';
-import { carouselMockData } from '@/pages/api/mock/carouselMock';
+
 import Footer from '@/components/footer/footer';
 function Home() {
   return (
@@ -25,9 +22,6 @@ function Home() {
         />
       </div>
       <CustomSection isLoggedIn={true} isGenreSelected={true} />
-      <div className="mt-80 mobile:mb-80 tablet:mb-120 pc:mb-140">
-        <Carousel data={carouselMockData} responsive={responsive} />
-      </div>
 
       <TodayBestSection />
       <BestSellerSection />

--- a/src/types/carouselType.ts
+++ b/src/types/carouselType.ts
@@ -1,7 +1,7 @@
 export type NewBook = {
   imageUrl: string;
   title: string;
-  authorname: string;
+  authorList: string[];
 };
 
 export type ResponSive = {

--- a/src/types/previewBookInfoType.ts
+++ b/src/types/previewBookInfoType.ts
@@ -13,4 +13,5 @@ export interface PreviewBookInfoProps extends PreviewBookInfoSizeProps {
   ranking?: number;
   price?: number;
   category?: string;
+  bookId?: number;
 }


### PR DESCRIPTION
## 구현사항

- [x] 메인페이지 신간 도서 섹션
- [x] 베스트셀러 섹션 api 연결

## 사용방법
main-page-api 의 메인페이지에서 확인 가능합니다. 

#TODO
맞춤도서 api 가 변경되는대로 맞춤도서 섹션 api 도 연결하겠습니다! 

## 스크린샷
<img width="709" alt="스크린샷 2024-02-16 오전 11 55 17" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/b209fc04-5785-4ef9-88a9-4434c5e9108e">

<img width="703" alt="스크린샷 2024-02-16 오전 11 55 26" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/727c31fe-a854-4aa8-9329-e6b1e7d69ed5">

##### close #265
##### close #266
##### close #297 