### PR TITLE
[#266] 메인페이지 신간도서 섹션 api 연결

### DIFF
--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -1,6 +1,7 @@
 import CarouselCard from '@/components/carousel/carouselCard';
 import useCarouselEnv from '@/hooks/useCarouselEnv';
-import { NewBook, ResponSive } from '@/types/carouselType';
+import { BookData } from '@/types/api/book';
+import { ResponSive } from '@/types/carouselType';
 import { inrange } from '@/utils/inrange';
 import registDragEvent from '@/utils/registerDragEvent';
 import Image from 'next/image';
@@ -9,7 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 const CARD_MARGIN_VALUE = 20;
 
 type CarouselProps = {
-  data: NewBook[];
+  data: BookData[];
   responsive: ResponSive;
 };
 
@@ -116,7 +117,9 @@ function Carousel({ data, responsive }: CarouselProps) {
             {data.map((item, index) => (
               <CarouselCard
                 key={index}
-                {...item}
+                authorList={item.authors}
+                title={item.bookTitle}
+                imageUrl={item.bookImgUrl as string}
                 imageSize={responsive[env].imageSize}
                 marginRight={CARD_MARGIN_VALUE}
                 size="md"

--- a/src/components/carousel/carouselCard.tsx
+++ b/src/components/carousel/carouselCard.tsx
@@ -6,21 +6,32 @@ export type CarouselCardProps = {
   size: 'sm' | 'md' | 'lg';
   imageUrl: string;
   title: string;
-  authorname: string;
+  authorList: string[];
   imageSize: ImageSize;
   marginRight: number;
 };
 
-function CarouselCard(props: CarouselCardProps) {
-  const { imageUrl, title, authorname, imageSize, marginRight, size } = props;
+function CarouselCard({
+  size,
+  imageUrl,
+  title,
+  authorList,
+  imageSize,
+  marginRight,
+}: CarouselCardProps) {
   const { width } = imageSize;
+  console.log('title', title);
   return (
     <div>
       <div
-        className={`text-white relative select-none`}
+        className={`relative select-none text-white`}
         style={{ width, marginRight }}>
-        <PreviewBookInfo size={size} title={title} authorList={[authorname]} />
-
+        <PreviewBookInfo
+          size={size}
+          title={title}
+          authorList={authorList}
+          image={imageUrl}
+        />
       </div>
     </div>
   );

--- a/src/components/carousel/categoryCarousel.tsx
+++ b/src/components/carousel/categoryCarousel.tsx
@@ -145,8 +145,10 @@ function CategoryCarousel({ data, responsive }: CarouselProps) {
             })}>
             {data.map((item, index) => (
               <CarouselCard
+                authorList={item.authorList}
                 key={index}
-                {...item}
+                imageUrl={item.imageUrl}
+                title={item.title}
                 imageSize={responsive[env].imageSize}
                 marginRight={calcMarginValue(env)}
                 size="sm"

--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -1,8 +1,19 @@
 import Link from 'next/link';
-import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
 import PreviewBookInfo from '@/components/book/previewBookInfo/previewBookInfo';
+import { useGetBook } from '@/api/book';
+import { BookData } from '@/types/api/book';
 
 function BestSellerSection() {
+  const { data } = useGetBook({
+    endpoint: '0/main',
+    params: {
+      bookId: '0',
+      limit: '10',
+      sort: 'BESTSELLER',
+      ascending: false,
+    },
+  });
+  const bookList: Array<BookData> = data ? data.data.books : [];
   return (
     <div
       className="flex-col mobile:mx-15 mobile:my-80 mobile:w-330 tablet:mx-40 tablet:my-120
@@ -14,26 +25,26 @@ function BestSellerSection() {
         </Link>
       </div>
       <div className="flex-center flex flex-wrap gap-x-10 gap-y-62 tablet:hidden pc:gap-x-30">
-        {bookOverviewsMock.map((book, index) => (
+        {bookList.map((book, index) => (
           <PreviewBookInfo
-            key={book.book.bookId}
+            key={book.bookId}
             size={'lg'}
-            title={book.book.bookTitle}
-            image={book.book.bookImgUrl}
-            authorList={book.book.authors}
+            title={book.bookTitle}
+            image={book.bookImgUrl}
+            authorList={book.authors}
             ranking={index + 1}
           />
         ))}
       </div>
 
       <div className="flex w-full flex-wrap justify-start gap-x-20 gap-y-62 mobile:hidden pc:hidden">
-        {bookOverviewsMock.map((book, index) => (
+        {bookList.map((book) => (
           <PreviewBookInfo
-            key={book.book.bookId}
+            key={book.bookId}
             size={'sm'}
-            title={book.book.bookTitle}
-            image={book.book.bookImgUrl}
-            authorList={book.book.authors}
+            title={book.bookTitle}
+            image={book.bookImgUrl}
+            authorList={book.authors}
           />
         ))}
       </div>

--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -38,13 +38,14 @@ function BestSellerSection() {
       </div>
 
       <div className="flex w-full flex-wrap justify-start gap-x-20 gap-y-62 mobile:hidden pc:hidden">
-        {bookList.map((book) => (
+        {bookList.map((book, index) => (
           <PreviewBookInfo
             key={book.bookId}
             size={'sm'}
             title={book.bookTitle}
             image={book.bookImgUrl}
             authorList={book.authors}
+            ranking={index + 1}
           />
         ))}
       </div>

--- a/src/pages/api/mock/carouselMock.ts
+++ b/src/pages/api/mock/carouselMock.ts
@@ -3,66 +3,66 @@ export const carouselMockData = [
     imageUrl:
       'https://cdn.pixabay.com/photo/2024/01/21/18/46/succulent-8523664_1280.jpg',
     title: '책1',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2022/11/08/06/05/read-7577787_1280.jpg',
     title: '책2',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2021/01/21/15/54/books-5937716_1280.jpg',
     title: '책3',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2024/01/16/19/40/trees-8512979_1280.jpg',
     title: '책4',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2024/01/13/00/46/raccoon-8504925_1280.png',
     title: '책5',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책6',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책7',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책8',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '책9',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '마지막이다',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
   {
     imageUrl:
       'https://cdn.pixabay.com/photo/2023/12/19/20/23/hazelnut-8458335_1280.jpg',
     title: '마지막2222222',
-    authorname: 'yuna',
+    authorList: ['yuna'],
   },
 ];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,10 +3,23 @@ import MainLayout from '@/components/layout/mainLayout';
 import CustomSection from '@/components/container/customSection/customSection';
 import BestSellerSection from '@/components/container/bestsellerSection/bestsellerSection';
 import Carousel from '@/components/carousel/carousel';
-import { carouselMockData } from './api/mock/carouselMock';
 import { responsive } from '@/utils/checkResponsiveEnv';
 import TodayBestSection from '@/components/container/todayBestSection/todayBestSection';
+import { useGetBook } from '@/api/book';
+import { BookData } from '@/types/api/book';
 function Home() {
+  const { data } = useGetBook({
+    endpoint: '0/main',
+    params: {
+      bookId: '0',
+      limit: '6',
+      sort: 'NEWEST',
+      ascending: false,
+    },
+  });
+
+  const bookList: Array<BookData> = data ? data.data.books : [];
+
   return (
     <>
       <div
@@ -24,7 +37,7 @@ function Home() {
       </div>
       <CustomSection isLoggedIn={true} isGenreSelected={true} />
       <div className="mt-80 mobile:mb-80 tablet:mb-120 pc:mb-140">
-        <Carousel data={carouselMockData} responsive={responsive} />
+        <Carousel data={bookList} responsive={responsive} />
       </div>
 
       <TodayBestSection />

--- a/src/pages/test/footer/index.tsx
+++ b/src/pages/test/footer/index.tsx
@@ -2,11 +2,7 @@ import { ReactElement } from 'react';
 import MainLayout from '@/components/layout/mainLayout';
 import CustomSection from '@/components/container/customSection/customSection';
 import BestSellerSection from '@/components/container/bestsellerSection/bestsellerSection';
-import Carousel from '@/components/carousel/carousel';
-
-import { responsive } from '@/utils/checkResponsiveEnv';
 import TodayBestSection from '@/components/container/todayBestSection/todayBestSection';
-import { carouselMockData } from '@/pages/api/mock/carouselMock';
 import Footer from '@/components/footer/footer';
 function Home() {
   return (
@@ -25,10 +21,6 @@ function Home() {
         />
       </div>
       <CustomSection isLoggedIn={true} isGenreSelected={true} />
-      <div className="mt-80 mobile:mb-80 tablet:mb-120 pc:mb-140">
-        <Carousel data={carouselMockData} responsive={responsive} />
-      </div>
-
       <TodayBestSection />
       <BestSellerSection />
       <Footer />

--- a/src/types/carouselType.ts
+++ b/src/types/carouselType.ts
@@ -1,7 +1,7 @@
 export type NewBook = {
   imageUrl: string;
   title: string;
-  authorname: string;
+  authorList: string[];
 };
 
 export type ResponSive = {


### PR DESCRIPTION
## 구현사항

- [x] 메인페이지 신간도서 섹션 api 연결

## 사용방법
/newestSection-api 브랜치 메인페이지에서 확인 가능합니다!

## 스크린샷
<img width="808" alt="스크린샷 2024-02-16 오후 1 28 52" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/412930d2-4fa3-456e-a30e-4350357403e8">


##### close #266