### PR TITLE
[#275] 스켈레톤 UI 적용 로직 수정

### DIFF
--- a/src/components/book/previewBookInfo/previewBookInfo.tsx
+++ b/src/components/book/previewBookInfo/previewBookInfo.tsx
@@ -30,16 +30,6 @@ function PreviewBookInfo({
     width: `${IMAGE_SIZE[size].widthOnly}`,
     height: `h-${IMAGE_SIZE[size].heightNumber.pc} tablet:h-${IMAGE_SIZE[size].heightNumber.tablet} mobile:h-${IMAGE_SIZE[size].heightNumber.mobile} `,
   };
-  const isLoading = false;
-  // const { data: bookList, isLoading } = useQuery({
-  //     queryKey: [""],
-  //     queryFn: () => { },
-  // });
-
-  // isLoading 시 스켈레톤 ui 렌더링
-  if (isLoading) {
-    return <SkeletonPreviewBookImage size={size} />;
-  }
 
   return (
     <Link href={`/bookdetail/${bookId}`}>

--- a/src/components/card/bookOverviewCard/bookOverViewCardList.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCardList.tsx
@@ -1,25 +1,40 @@
 import BookOverviewCard from './bookOverViewCard';
 import { BookData } from '@/types/api/book';
 import BookOverviewEmptyCard from './bookOverviewEmptyCard';
+import SkeletonBookOverviewCard from '@/components/skeleton/bookOverviewCard/skeleton';
 
 interface BookOverViewCardListProps {
   bookData: BookData[];
   title: string;
+  isLoading: boolean;
 }
 
-function BookOverViewCardList({ title, bookData }: BookOverViewCardListProps) {
+function BookOverViewCardList({
+  title,
+  bookData,
+  isLoading,
+}: BookOverViewCardListProps) {
   return (
     <div className="flex flex-col gap-40 pb-40 text-black">
       <h1 className="text-20 font-bold">{title}</h1>
       <div className="flex flex-col gap-20 mobile:gap-10">
-        {bookData.length !== 0 ? (
+        {isLoading ? (
+          // 로딩 중이면 5개의 스켈레톤 UI 렌더링
+          Array.from({
+            length: 5,
+          }).map((_, index) => (
+            <SkeletonBookOverviewCard key={index} size="sm" />
+          ))
+        ) : bookData.length === 0 ? (
+          // 로딩 중이 아니고 데이터가 없으면 빈 카드 표시
+          <BookOverviewEmptyCard />
+        ) : (
+          // 로딩 중이 아니고 데이터가 있으면 데이터 렌더링
           bookData.map((data, index) => (
             <div key={data?.bookId}>
               <BookOverviewCard book={data} rank={index + 1} />
             </div>
           ))
-        ) : (
-          <BookOverviewEmptyCard />
         )}
       </div>
     </div>

--- a/src/components/skeleton/bookOverviewCard/skeleton.tsx
+++ b/src/components/skeleton/bookOverviewCard/skeleton.tsx
@@ -1,69 +1,66 @@
-
+import { PreviewBookInfoSizeProps } from '@/types/previewBookInfoType';
 import { SKELETON_COMMON_STYLE } from 'src/constants/style/skeletonCommonStyle';
+import SkeletonPreviewBookImage from '../previewBookImage/skeleton';
 
-SKELETON_COMMON_STYLE;
-
-function SkeletonBookOverviewCard() {
+function SkeletonBookOverviewCard({ size }: PreviewBookInfoSizeProps) {
   return (
     <div
       role="card-container"
-      className="border-2 border-gray-1 flex flex-col justify-between h-220 p-30 rounded-lg
-        mobile:p-15 mobile:pb-15 mobile:w-330 mobile:h-251 relative animate-pulse">
-      <div role="book-info-container" className="flex relative">
-        <div
-          role="image"
-          className="w-112 h-170 mobile:w-93 mobile:h-141"></div>
+      className="relative flex h-220 animate-pulse flex-col justify-between rounded-lg border-2
+        border-gray-1 p-30 mobile:h-251 mobile:w-330 mobile:p-15 mobile:pb-15">
+      <div role="book-info-container" className="relative flex">
+        <SkeletonPreviewBookImage size={size} />
         <div
           role="book-info"
-          className="flex flex-col justify-start items-start gap-8 ml-30 mr-auto mobile:max-w-185
-            mobile:ml-12 mobile:gap-4">
+          className="ml-30 mr-auto flex flex-col items-start justify-start gap-8 mobile:ml-12
+            mobile:max-w-185 mobile:gap-4">
           <div
             role="title"
-            className={`${SKELETON_COMMON_STYLE} w-250 tablet:w-200 mobile:w-180 h-25 mobile:h-40`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-25 w-250 mobile:h-40 mobile:w-180 tablet:w-200`}></div>
           <div role="author-publisher" className="flex-center gap-4">
             <div
               role="author"
-              className={`${SKELETON_COMMON_STYLE} w-100 h-15`}></div>
+              className={`${SKELETON_COMMON_STYLE} h-15 w-100`}></div>
             <div
               role="publisher "
-              className={`${SKELETON_COMMON_STYLE} w-100 h-15 mobile:hidden`}></div>
+              className={`${SKELETON_COMMON_STYLE} h-15 w-100 mobile:hidden`}></div>
           </div>
           <div
             role="published-date"
-            className={`${SKELETON_COMMON_STYLE} w-100 h-15`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-15 w-100`}></div>
           <div
             role="rating"
-            className={`${SKELETON_COMMON_STYLE} w-100 h-15`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-15 w-100`}></div>
           <div
             role="category"
-            className={`${SKELETON_COMMON_STYLE} w-100 h-15 pc:hidden tablet:hidden`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-15 w-100 tablet:hidden pc:hidden`}></div>
           <div
             role="price"
-            className={`${SKELETON_COMMON_STYLE} w-100 h-15`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-15 w-100`}></div>
         </div>
         <div
           role="buttons"
-          className="flex flex-col items-end gap-30 tablet:absolute tablet:right-0 mobile:absolute
-            mobile:bottom-16 mobile:right-0">
+          className="flex flex-col items-end gap-30 mobile:absolute mobile:bottom-16 mobile:right-0
+            tablet:absolute tablet:right-0">
           <div
             role="like-button"
-            className="rounded-lg border-2 border-gray-1 flex-center flex-col gap-2 bg-gray-1 w-22 h-22"></div>
+            className="flex-center h-22 w-22 flex-col gap-2 rounded-lg border-2 border-gray-1 bg-gray-1"></div>
           <div
             role="cart-button"
             className="flex flex-col gap-12 mobile:hidden">
-            <div className="rounded-lg border-2 border-gray-1 bg-gray-1 w-130 h-40 mobile:w-140"></div>
-            <div className="rounded-lg border-2 border-gray-1 bg-gray-1 w-130 h-40 mobile:w-140"></div>
+            <div className="h-40 w-130 rounded-lg border-2 border-gray-1 bg-gray-1 mobile:w-140"></div>
+            <div className="h-40 w-130 rounded-lg border-2 border-gray-1 bg-gray-1 mobile:w-140"></div>
           </div>
         </div>
       </div>
       {/* 모바일에서만 보이는 컴포넌트(장바구니/구매하기 버튼)*/}
-      <div role="mobile-section" className="pt-10 pc:hidden tablet:hidden">
-        <div className="w-328 absolute left-0 bottom-70 border border-b-1 border-gray-1"></div>
+      <div role="mobile-section" className="pt-10 tablet:hidden pc:hidden">
+        <div className="border-b-1 absolute bottom-70 left-0 w-328 border border-gray-1"></div>
         <div role="mobile-cart-button" className="flex gap-10">
           <div
-            className={`${SKELETON_COMMON_STYLE} w-130 h-40 mobile:w-140`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-40 w-130 mobile:w-140`}></div>
           <div
-            className={`${SKELETON_COMMON_STYLE} w-130 h-40 mobile:w-140`}></div>
+            className={`${SKELETON_COMMON_STYLE} h-40 w-130 mobile:w-140`}></div>
         </div>
       </div>
     </div>
@@ -71,4 +68,3 @@ function SkeletonBookOverviewCard() {
 }
 
 export default SkeletonBookOverviewCard;
-

--- a/src/pages/domestic/[category]/bestseller/index.tsx
+++ b/src/pages/domestic/[category]/bestseller/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'BESTSELLER' });
 
 function BestSellerPage() {
   const { categoryId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function BestSellerPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="bestseller" />}
-        main={<BookOverViewCardList bookData={bookData} title="베스트셀러" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="베스트셀러"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/domestic/[category]/newest/index.tsx
+++ b/src/pages/domestic/[category]/newest/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'NEWEST' });
 
 function NewestPage() {
   const { categoryId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function NewestPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="newest" />}
-        main={<BookOverViewCardList bookData={bookData} title="신간 도서" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="신간 도서"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/domestic/bestseller/index.tsx
+++ b/src/pages/domestic/bestseller/index.tsx
@@ -12,7 +12,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'BESTSELLER' });
 
 function BestSellerPage() {
   const { mainId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function BestSellerPage() {
     <BestSellerPageLayout
       header={<Header isLoggedIn={true} />}
       sideBar={<Sidebar pageName="bestseller" />}
-      main={<BookOverViewCardList title="베스트셀러" bookData={bookData} />}
+      main={
+        <BookOverViewCardList
+          title="베스트셀러"
+          bookData={bookData}
+          isLoading={isLoading}
+        />
+      }
     />
   );
 }

--- a/src/pages/domestic/newest/index.tsx
+++ b/src/pages/domestic/newest/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'NEWEST' });
 
 function NewestPage() {
   const { mainId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function NewestPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="newest" />}
-        main={<BookOverViewCardList bookData={bookData} title="신간 도서" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="신간 도서"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/foreign/[category]/bestseller/index.tsx
+++ b/src/pages/foreign/[category]/bestseller/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'BESTSELLER' });
 
 function BestSellerPage() {
   const { categoryId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function BestSellerPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="bestseller" />}
-        main={<BookOverViewCardList bookData={bookData} title="베스트셀러" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="베스트셀러"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/foreign/[category]/newest/index.tsx
+++ b/src/pages/foreign/[category]/newest/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'NEWEST' });
 
 function NewestPage() {
   const { categoryId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function NewestPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="newest" />}
-        main={<BookOverViewCardList bookData={bookData} title="신간 도서" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="신간 도서"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/foreign/bestseller/index.tsx
+++ b/src/pages/foreign/bestseller/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'BESTSELLER' });
 
 function BestSellerPage() {
   const { mainId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function BestSellerPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="bestseller" />}
-        main={<BookOverViewCardList bookData={bookData} title="베스트셀러" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="베스트셀러"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/foreign/newest/index.tsx
+++ b/src/pages/foreign/newest/index.tsx
@@ -11,7 +11,7 @@ const INITIAL_PARAMS = useInitialBestNewestParams({ sort: 'NEWEST' });
 
 function NewestPage() {
   const { mainId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
   });
@@ -22,7 +22,13 @@ function NewestPage() {
       <BestSellerPageLayout
         header={<Header isLoggedIn={true} />}
         sideBar={<Sidebar pageName="newest" />}
-        main={<BookOverViewCardList bookData={bookData} title="신간 도서" />}
+        main={
+          <BookOverViewCardList
+            bookData={bookData}
+            title="신간 도서"
+            isLoading={isLoading}
+          />
+        }
       />
     </div>
   );

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -1,7 +1,5 @@
 import PreviewBookInfo from '@/components/book/previewBookInfo/previewBookInfo';
-import BookOverviewCard from '@/components/card/bookOverviewCard/bookOverViewCard';
 import ShippingAddressSection from '@/components/container/shippingAddressSection/shippingAddressSection';
-import SkeletonBookOverviewCard from '@/components/skeleton/bookOverviewCard/skeleton';
 import SkeletonPreviewBookImage from '@/components/skeleton/previewBookImage/skeleton';
 import { bookOverviewsMock } from '@/pages/api/mock/bestSellerMock';
 import { useState } from 'react';
@@ -38,9 +36,6 @@ function TestPage() {
 
   return (
     <div className="flex flex-col gap-20 p-20">
-      {/* <SkeletonPreviewBookImage size="sm" />
-      <SkeletonPreviewBookImage size="md" />
-      <SkeletonPreviewBookImage size="lg" /> */}
       <PreviewBookInfo
         title="하이용"
         authorList={['얌얌', '능이버섯']}
@@ -69,7 +64,6 @@ function TestPage() {
         // itemsStart
       />
 
-      <SkeletonBookOverviewCard />
       <div className="flex gap-10">
         <SkeletonPreviewBookImage size="lg" />
         <SkeletonPreviewBookImage size="md" />


### PR DESCRIPTION
## 구현사항

브랜치가 날아갔지만 당황하지 않고 빠르게 복구....

- isLoading일때만 스켈레톤 UI 가 보이게했습니다.
- previewBookInfo에서는 스켈레톤 관련 UI 를 제거했어요
- SkeletonBookOverviewCard에서 size를 받아 previewBookInfo스켈레톤 UI를 함께 랜더링 하도록 변경했어요.

## 사용방법

기본적으로 5개의 스켈레톤 카드 ui가 보이도록 했습니다.
데이터가 없을 경우에도 5개 스켈레톤이 보입니다.
데이터가 받아온 이후에야 확실한 data.length값을 알 수 있어서...
없어도 5개는 기본으로 보이게 했습니다.
더 좋은 방법 아시면 코멘트 남겨주세용!


![스크린샷 2024-02-16 오후 3 00 45](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/e8763a19-2cf4-49af-9ba6-75269012868c)


## 스크린샷

https://github.com/bookstore-README/front_bookstore-README/assets/120437902/f9556cd8-86af-4aa7-a359-3c359b5ccbc8





##### close #275 
