### PR TITLE
[#269] 제품상세페이지 상단 제품 info 디자인 수정 및 스켈레톤 추가

### DIFF
--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -13,10 +13,10 @@ interface BookDetailCardProps {
   authors: string[];
   bookmarkCount: number;
   isBookmarked: boolean;
-  publishedAt: string;
+  publishedDate: string;
   publisher: string;
   averageRating: number;
-  reviewNum: number;
+  reviewCount: number;
   orderCount: number;
   setOrderCount: (n: number) => void;
 }
@@ -30,10 +30,10 @@ function BookDetailCard({
   authors,
   bookmarkCount,
   isBookmarked,
-  publishedAt,
+  publishedDate,
   publisher,
   averageRating,
-  reviewNum,
+  reviewCount,
   orderCount,
   setOrderCount,
 }: BookDetailCardProps) {
@@ -42,17 +42,17 @@ function BookDetailCard({
       <BookDetailImg imageUrl={bookImgUrl} />
       <article
         role="info"
-        className="flex flex-col gap-57 justify-start items-start mobile:w-full">
+        className="flex flex-col gap-40 mobile:gap-30 justify-start items-start w-full max-w-[525px]">
         <BookDetailInfo
-          title={bookTitle}
-          categoryList={categories}
+          bookTitle={bookTitle}
+          categories={categories}
           authors={authors}
           isBookmarked={isBookmarked}
-          bookmarkNum={bookmarkCount}
-          publishedAt={publishedAt}
+          bookmarkCount={bookmarkCount}
+          publishedDate={publishedDate}
           publisher={publisher}
-          rating={averageRating}
-          reviewNum={reviewNum}
+          averageRating={averageRating}
+          reviewCount={reviewCount}
           price={price}
         />
         <StaticOrderNavigator

--- a/src/components/card/bookDetailCard/bookDetailImg.tsx
+++ b/src/components/card/bookDetailCard/bookDetailImg.tsx
@@ -5,7 +5,7 @@ function BookDetailImg({ imageUrl }: { imageUrl?: string | null }) {
   return (
     <article
       role="img"
-      className="bg-gray-5 relative w-[525px] h-[797px] tablet:min-w-[334px] tablet:max-w-[334px]
+      className="bg-gray-5 flex relative min-w-[525px] max-w-[525px] h-[797px] tablet:min-w-[334px] tablet:max-w-[334px]
         tablet:h-[526px] mobile:min-w-[330px] mobile:max-w-[330px] mobile:h-[500px]">
       <Image
         src={imageUrl ?? TestImage1}

--- a/src/components/card/bookDetailCard/bookDetailInfo.tsx
+++ b/src/components/card/bookDetailCard/bookDetailInfo.tsx
@@ -1,55 +1,50 @@
 import Image from 'next/image';
+
 import BookCategory from '@/components/book/bookCategory/bookCategory';
 import BookPrice from '@/components/book/bookPrice/bookPrice';
 import BookRating from '@/components/book/bookRating/bookRating';
 import LikeButton from '@/components/button/likeButton';
 import Spacing from '@/components/container/spacing/spacing';
-import React, { useState } from 'react';
 import BookAuthor from '@/components/book/bookAuthor/bookAuthor';
 
-interface TempProps {
-  title: string;
-  categoryList: [string, string];
+interface BookDetailInfoProps {
+  bookTitle: string;
+  categories: [string, string];
   isBookmarked: boolean;
-  bookmarkNum: number;
-  authors?: [] | string[];
+  bookmarkCount: number;
+  authors?: string[];
   publisher?: string;
-  publishedAt: string;
-  rating: number;
-  reviewNum: number;
+  publishedDate: string;
+  averageRating: number;
+  reviewCount: number;
   price: number;
 }
 
 function BookDetailInfo({
-  title,
-  categoryList,
-  isBookmarked: myBookmarked,
-  bookmarkNum,
+  bookTitle,
+  categories,
+  isBookmarked,
+  bookmarkCount,
   authors,
-  publishedAt,
+  publishedDate,
   publisher,
-  rating,
-  reviewNum,
+  averageRating,
+  reviewCount,
   price,
-}: TempProps) {
-  const [isBookmarked, setIsBookmarked] = useState(myBookmarked || false);
-  const [bookmarkCount, setIsBookmarkCount] = useState(bookmarkNum || 0);
+}: BookDetailInfoProps) {
 
   const handleBookmarkClick = () => {
-    setIsBookmarked(!isBookmarked);
-    if (!isBookmarked) setIsBookmarkCount((prevCount) => prevCount + 1);
-    else setIsBookmarkCount((prevCount) => prevCount - 1);
   };
 
   return (
     <article
       role="info"
-      className="flex flex-col justify-start items-start grow mobile:w-full">
-      <BookCategory categories={categoryList} />
+      className="flex flex-col max-w-[525px] justify-start items-start grow mobile:w-full">
+      <BookCategory categories={categories} />
       <Spacing height={[4, 4, 4]} />
       <div className="flex justify-between items-center w-full gap-20">
         <h3 className="font-bold text-[22px] text-gray-4 text-pretty">
-          {title}
+          {bookTitle}
         </h3>
         <div className="flex justify-center gap-24">
           <div className="flex-center flex-col">
@@ -70,16 +65,16 @@ function BookDetailInfo({
       <BookAuthor authorList={authors} />
       <div className="h-[1px] w-full bg-gray-1 max-w-[525px] my-20 mobile:my-12"></div>
       <div className="text-14 text-gray-3">
-        {publisher} | {publishedAt}
+        {publisher} | {publishedDate}
       </div>
       <Spacing height={[12, 12, 12]} />
 
       <div role="rating" className="flex gap-6">
-        <BookRating rating={rating} size="md" />
+        <BookRating rating={averageRating} size="md" />
         <span className="relative top-12 text-gray-3 text-14">
-          ({reviewNum})
+          ({reviewCount})
         </span>
-        <span className="text-green font-bold text-[24px]">{rating}</span>
+        <span className="text-green font-bold text-[24px]">{averageRating}</span>
       </div>
       <Spacing height={[12, 12, 12]} />
       <BookPrice

--- a/src/components/orderNavigator/staticOrderNavigator.tsx
+++ b/src/components/orderNavigator/staticOrderNavigator.tsx
@@ -16,8 +16,8 @@ function StaticOrderNavigator({
 }: OrderNavigatorProps) {
   return (
     <div
-      className="bg-gray-5 rounded-[10px] p-20 w-full max-w-[525px] h-154 tablet:h-150
-        mobile:w-330 mobile:h-130 mx-auto flex flex-col gap-20 mobile:p-15 mobile:gap-10">
+      className="bg-gray-5 rounded-[10px] p-20 w-full max-w-[525px] min-w-[525px] h-154 tablet:h-150 tablet:min-w-330
+        mobile:min-w-330 mobile:h-130 mobile:mx-auto flex flex-col gap-20 mobile:p-15 mobile:gap-10">
       <div className="flex justify-between">
         <OrderBookCount
           count={orderCount}

--- a/src/components/skeleton/bookDetailCard/skeleton.tsx
+++ b/src/components/skeleton/bookDetailCard/skeleton.tsx
@@ -1,0 +1,32 @@
+
+import { SKELETON_COMMON_STYLE } from 'src/constants/style/skeletonCommonStyle';
+
+SKELETON_COMMON_STYLE;
+
+function SkeletonBookDetailCard() {
+  return (
+    <section className="flex justify-start gap-20 items-start mobile:flex-col mobile:flex-center">
+      <article className={`${SKELETON_COMMON_STYLE} rounded-[10px] w-[525px] h-[757px] tablet:w-[334px] tablet:h-[526px] mobile:w-[330px] h-[550px]`}>
+      </article>
+
+      <article className="flex flex-col gap-40 mobile:gap-30 justify-start items-start mobile:w-full">
+        <div className='flex flex-col gap-4'>
+          <div className={`${SKELETON_COMMON_STYLE} h-22 w-100`}></div>
+          <div className={`${SKELETON_COMMON_STYLE} h-30 w-355`}></div>
+          <div className={`${SKELETON_COMMON_STYLE} h-22 w-175`}></div>
+          <div className='bg-gray-5 w-full h-[1px]'></div>
+          <div className={`${SKELETON_COMMON_STYLE} h-19 w-300`}></div>
+          <div className={`${SKELETON_COMMON_STYLE} h-30 w-240`}></div>
+          <div className={`${SKELETON_COMMON_STYLE} h-38 w-130`}></div>
+        </div>
+        <div className={`${SKELETON_COMMON_STYLE} rounded-[10px] w-full h-154 mobile:h-130 `}>
+
+        </div>
+      </article>
+
+    </section>
+  );
+}
+
+export default SkeletonBookDetailCard;
+

--- a/src/components/skeleton/bookDetailCard/skeleton.tsx
+++ b/src/components/skeleton/bookDetailCard/skeleton.tsx
@@ -1,12 +1,11 @@
 
 import { SKELETON_COMMON_STYLE } from 'src/constants/style/skeletonCommonStyle';
 
-SKELETON_COMMON_STYLE;
 
 function SkeletonBookDetailCard() {
   return (
     <section className="flex justify-start gap-20 items-start mobile:flex-col mobile:flex-center">
-      <article className={`${SKELETON_COMMON_STYLE} rounded-[10px] w-[525px] h-[757px] tablet:w-[334px] tablet:h-[526px] mobile:w-[330px] h-[550px]`}>
+      <article className={`${SKELETON_COMMON_STYLE} rounded-[10px] w-[525px] h-[757px] tablet:w-[334px] tablet:h-[526px] mobile:w-[330px] mobile:h-[550px]`}>
       </article>
 
       <article className="flex flex-col gap-40 mobile:gap-30 justify-start items-start mobile:w-full">
@@ -19,7 +18,7 @@ function SkeletonBookDetailCard() {
           <div className={`${SKELETON_COMMON_STYLE} h-30 w-240`}></div>
           <div className={`${SKELETON_COMMON_STYLE} h-38 w-130`}></div>
         </div>
-        <div className={`${SKELETON_COMMON_STYLE} rounded-[10px] w-full h-154 mobile:h-130 `}>
+        <div className={`${SKELETON_COMMON_STYLE} rounded-[10px] pc:w-[525px] w-full h-154 mobile:h-130 `}>
 
         </div>
       </article>

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -11,7 +11,9 @@ import Review from '@/components/review/review';
 import Spacing from '@/components/container/spacing/spacing';
 import SideOrderNavigator from '@/components/orderNavigator/sideOrderNavigator';
 import FooterOrderNavitgator from '@/components/orderNavigator/footerOrderNavitgator';
-import { BookDetailNavLocationType } from '@/types/bookDetailtype';
+import SkeletonBookDetailCard from '@/components/skeleton/bookDetailCard/skeleton';
+
+type BookDetailNavLocationType = "information" | "review" | "currency"
 
 export default function BookDetailPage() {
   const router = useRouter();
@@ -28,66 +30,63 @@ export default function BookDetailPage() {
       },
   })
 
-  // TODO isLoading 에선 스켈레톤 ui 보여주게 할 것.
-  // TODO 로그인 안된 경우 찜 버튼 못 누르게 혹은 로그인하라는 alert 창 뜨게
-  // TODO 상품정보 이거 어쩌징
-  // TODO 리뷰가 없을 때 보여줄 이미지 뭐 리뷰가 없어요! 이런거 만들기
-  // TODO 로그인한경우 찜되게끔 찜 버튼 연결
-  // TODO 로그인한경우 조회수 올라가게 조회수 api 연결
-  // TODO 공유하기버튼 연결
-  // TODO 장바구니, 구매하기 버튼 연결
   return (
     <MainLayout>
-        <section className="flex flex-col w-full p-40 mobile:p-19 mobile:flex-center">
-          <BookDetailCard
-            bookId={bookId as string}
-            bookImgUrl={data?.data.bookImgUrl ?? "/"}
-            bookTitle={data?.data.bookTitle ?? ""}
-            price={data?.data.price ?? 0}
-            categories={data?.data.categories ?? ["",""]}
-            authors={data?.data.authors ??[""]}
-            bookmarkCount={data?.data.bookmarkCount ?? 0}
-            isBookmarked={data?.data.isBookmarked ?? false}
-            publishedAt={data?.data.publishedDate ?? ""}
-            publisher={data?.data.publisher ?? ""}
-            averageRating={data?.data?.averageRating ?? 0}
-            reviewNum={data?.data.reviewCount ?? 0}
-            orderCount={orderCount}
-            setOrderCount={setOrderCount}
+      <section className="flex gap-34 p-40 w-full max-w-[1200px] mobile:p-19 flex-center mobile:flex-col">
+        { (isLoading || isError || !data) ? <SkeletonBookDetailCard /> : 
+        <BookDetailCard
+          bookId = {bookId as string}
+          bookImgUrl = {data?.data.bookImgUrl}
+          bookTitle={data?.data.bookTitle}
+          price={data?.data.price}
+          categories={data?.data.categories}
+          authors={data?.data.authors}
+          bookmarkCount={data?.data.bookmarkCount}
+          isBookmarked={false}
+          publishedDate={data?.data.publishedDate}
+          publisher={data?.data.publisher}
+          averageRating={data?.data.averageRating}
+          reviewCount={data?.data.reviewCount}
+          orderCount={orderCount}
+          setOrderCount={setOrderCount}
           />
-        </section>
-        <Spacing height={[80, 80, 40]} />
-        <BookDetailNav
-          reviewNum={data?.data.reviewCount}
-          location={location}
-          setLocation={setLocation}
-        />
-        <div className="flex flex-col w-full">
-          <section
-            className="flex p-40 justify-start gap-30 pt-120 mobile:p-19 mobile:pt-40
-              mobile:flex-center">
-            <div className="flex flex-col w-full max-w-[710px] mobile:flex-center">
-              {location === 'information' && <BookInformation />}
+        }
+      </section>
+      
+      <Spacing height={[80, 80, 40]} />
+      <BookDetailNav
+        reviewNum={data?.data.reviewCount}
+        location={location}
+        setLocation={setLocation}
+      />
+      
+      <div className="flex-center flex-col w-full max-w-[1200px]">
+        <section
+          className="flex p-40 w-full mb-100 gap-30 pt-120 mobile:p-19 mobile:pt-40 tablet:flex-center mobile:flex-center">
+          <div className="max-w-[710px] w-[100%] min-w-330">
+            {location === 'information' && <BookInformation />}
             {location === 'review' && <Review reviewNum={data?.data?.reviewCount} reviewList={data?.data?.reviews} />}
-              {location === 'currency' && <RefundTerm />}
-            </div>
-            <div className="pc:pt-50 pc:flex hidden">
-              <SideOrderNavigator
-                isBookmarked={data?.data.isBookmarked ?? false}
-                price={data?.data.price ?? 0}
-                orderCount={orderCount}
-                setOrderCount={setOrderCount}
-              />
-            </div>
-          </section>
-          <FooterOrderNavitgator
-            isBookmarked={data?.data.isBookmarked ?? false}
-            price={data?.data.price ?? 0}
-            bookId={bookId as string}
-            orderCount={orderCount}
-            setOrderCount={setOrderCount}
-          />
-        </div>
-      </MainLayout>
+            {location === 'currency' && <RefundTerm />}
+          </div>
+
+          <div className="pc:pt-50 pc:flex hidden">
+            <SideOrderNavigator
+              isBookmarked={false}
+              price={data?.data.price ?? 0}
+              orderCount={orderCount}
+              setOrderCount={setOrderCount}
+            />
+          </div>
+        </section>
+
+        <FooterOrderNavitgator
+          isBookmarked={false}
+          price={data?.data.price ?? 0}
+          bookId={bookId as string}
+          orderCount={orderCount}
+          setOrderCount={setOrderCount}
+        />
+      </div>
+    </MainLayout>
   );
 }


### PR DESCRIPTION
## 구현사항

1. 제품 상세페이지에서 레이아웃이 뒤틀리는 문제가 있었는데, 다 수정했습니다. 봤을 때 디자인적으론 별 반 차이 없습니다!!
2. 스켈레톤 ui 추가했습니다. COMMON SKELETON STYLE을 만들어주신 승연님께 꾸벅.. u.u


-[] 구현한 내용 및 설명

## 사용방법

localohost:3000/bookdetail/35 등등 
아무 책이나 들어가면 바로 확인할 수 있습니다!!
skeleton 은 slow 3g 환경에서 볼 수 있습니다. 

## 스크린샷

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/548586cd-9b48-4e4a-9fbc-4705fa2dacc5)

![Honeycam 2024-02-14 23-15-55](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/bcdc5436-c9ea-434d-a6a5-f5e572418686)


##### close #269
