### PR TITLE
[#247 ] 카테고리 페이지 버그 수정 및 스켈레톤 추가

### DIFF
--- a/src/components/button/sidebar/sidebarTab.tsx
+++ b/src/components/button/sidebar/sidebarTab.tsx
@@ -16,7 +16,7 @@ function SidebarTab({ pageName}: SidebarProps) {
         mobile:flex-wrap mobile:gap-5 mobile:rounded-[10px] mobile:border-[1px] mobile:border-gray-1 mobile:p-15">
       <Link
         className={`block text-[13px] ${subId ? 'text-gray-2' : 'font-bold text-green'}`}
-        href={`/${mainId === 0 ? 'domestic' : 'foreign'}`}>
+        href={`/${mainId === 0 ? 'domestic' : 'foreign'}/${pageName}`}>
         전체보기
       </Link>
       {(categoryList) && (categoryList[mainId === 0 ? "domestic" : "foreign"] ?? []).map((el, ind) => {

--- a/src/components/button/sidebar/sidebarTab.tsx
+++ b/src/components/button/sidebar/sidebarTab.tsx
@@ -5,9 +5,9 @@ import { CategoryListAtom } from '@/store/state';
 import { SidebarProps } from '@/types/sidebarType';
 import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
 
-function SidebarTab({ pageName}: SidebarProps) {
-  const [categoryList,] = useAtom(CategoryListAtom);
-  const { mainId, subId, categoryId } = useCheckCategoryUrl();  
+function SidebarTab({ pageName }: SidebarProps) {
+  const [categoryList] = useAtom(CategoryListAtom);
+  const { mainId, subId, categoryId } = useCheckCategoryUrl();
 
   return (
     <div
@@ -16,23 +16,24 @@ function SidebarTab({ pageName}: SidebarProps) {
         mobile:flex-wrap mobile:gap-5 mobile:rounded-[10px] mobile:border-[1px] mobile:border-gray-1 mobile:p-15">
       <Link
         className={`block text-[13px] ${subId ? 'text-gray-2' : 'font-bold text-green'}`}
-        href={`/${mainId === 0 ? 'domestic' : 'foreign'}/${pageName}`}>
+        href={`/${mainId === 0 ? 'domestic' : 'foreign'}/${pageName ?? ''}`}>
         전체보기
       </Link>
-      {(categoryList) && (categoryList[mainId === 0 ? "domestic" : "foreign"] ?? []).map((el, ind) => {
-        return (
-          <Link
-              className={`block text-[13px] ${
-                (el.subId) === (subId)
-                  ? 'font-bold text-green'
-                  : 'text-gray-2'
-              }`}
-              href={`/${mainId === 0 ? 'domestic' : 'foreign'}${el.link}${pageName ? `/${pageName}` : ''}`}
-              key={el?.categoryId}>
-            {el?.subName}
-          </Link>
-        );
-      })}
+      {categoryList &&
+        (categoryList[mainId === 0 ? 'domestic' : 'foreign'] ?? []).map(
+          (el, ind) => {
+            return (
+              <Link
+                className={`block text-[13px] ${
+                  el.subId === subId ? 'font-bold text-green' : 'text-gray-2'
+                }`}
+                href={`/${mainId === 0 ? 'domestic' : 'foreign'}${el.link}${pageName ? `/${pageName}` : ''}`}
+                key={el?.categoryId}>
+                {el?.subName}
+              </Link>
+            );
+          },
+        )}
     </div>
   );
 }

--- a/src/components/container/categoryBookList/mainCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/mainCategoryBookList.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { getBook } from '@/api/book';
 import PreviewBookInfo from '@/components/book/previewBookInfo/previewBookInfo';
 import DropDown from '@/components/dropDown/dropDown';
-import SkeletonPreviewBookInfo from '@/components/skeleton/previewBookInfo/skeleton';
+import SkeletonPreviewBookImage from '@/components/skeleton/previewBookImage/skeleton';
 import useCarouselEnv from '@/hooks/useCarouselEnv';
 import useInfinite from '@/hooks/useInfinite';
 import useCustomInfiniteQuery from '@/hooks/useCustomInfiniteQuery';
@@ -90,7 +90,7 @@ function MainCategoryBookList() {
           className="grid min-h-400 w-[895px]
            grid-flow-row auto-rows-auto grid-cols-5 gap-x-20 gap-y-40 mobile:w-[330px] mobile:grid-cols-2 mobile:gap-y-0 tablet:w-[511px] tablet:grid-cols-3 ">
           {[0, 1, 2, 3, 4].map((el) => {
-            return <SkeletonPreviewBookInfo key={el} />;
+            return <SkeletonPreviewBookImage size="md" key={el} />;
           })}
         </div>
       )}

--- a/src/components/container/categoryBookList/mainCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/mainCategoryBookList.tsx
@@ -8,9 +8,10 @@ import SkeletonPreviewBookInfo from '@/components/skeleton/previewBookInfo/skele
 import useCarouselEnv from '@/hooks/useCarouselEnv';
 import useInfinite from '@/hooks/useInfinite';
 import useCustomInfiniteQuery from '@/hooks/useCustomInfiniteQuery';
+import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
+import SelectOrder from '@/utils/selectOrder';
 
 import { BOOK_OLDER_STANDARD } from 'src/constants/orderList';
-import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
 
 const CURRENT_ORDER = {
   sort: 'VIEW',
@@ -48,34 +49,7 @@ function MainCategoryBookList() {
       });
     },
   });
-
-  const onSelectedOrder = (menu: string) => {
-    setSelectedOrder(menu);
-    if (menu === '조회순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'VIEW', ascending: false };
-      });
-    if (menu === '신상품순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'NEWEST', ascending: false };
-      });
-    if (menu === '별점순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'STAR', ascending: false };
-      });
-    if (menu === '리뷰 많은순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'REVIEW', ascending: false };
-      });
-    if (menu === '낮은 가격순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'PRICE', ascending: true };
-      });
-    if (menu === '높은 가격순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'PRICE', ascending: false };
-      });
-  };
+  const onSelectedOrder = SelectOrder(setSelectedOrder, setCurrentOrder);
 
   return (
     <article className="relative flex h-fit flex-col gap-50 pb-30 mobile:gap-20 tablet:gap-40">
@@ -115,8 +89,7 @@ function MainCategoryBookList() {
         <div
           className="grid min-h-400 w-[895px]
            grid-flow-row auto-rows-auto grid-cols-5 gap-x-20 gap-y-40 mobile:w-[330px] mobile:grid-cols-2 mobile:gap-y-0 tablet:w-[511px] tablet:grid-cols-3 ">
-          {' '}
-          {[0, 1, 2].map((el) => {
+          {[0, 1, 2, 3, 4].map((el) => {
             return <SkeletonPreviewBookInfo key={el} />;
           })}
         </div>

--- a/src/components/container/categoryBookList/mainCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/mainCategoryBookList.tsx
@@ -81,7 +81,7 @@ function MainCategoryBookList() {
     <article className="relative flex h-fit flex-col gap-50 pb-30 mobile:gap-20 tablet:gap-40">
       <div className="flex items-center justify-between">
         <h1 className="text-20 text-black">모든 도서</h1>
-        <div className="z-20">
+        <div className="z-20 w-120">
           <DropDown
             menus={BOOK_OLDER_STANDARD}
             selectedItem={selectedOrder}

--- a/src/components/container/categoryBookList/subCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/subCategoryBookList.tsx
@@ -81,7 +81,7 @@ function SubCategoryBookList() {
     <article className="relative flex h-fit flex-col gap-50 pb-30 mobile:gap-20 tablet:gap-40">
       <div className="flex items-center justify-between">
         <h1 className="text-20 text-black">모든 도서</h1>
-        <div className="z-20">
+        <div className="z-20 w-120">
           <DropDown
             menus={BOOK_OLDER_STANDARD}
             selectedItem={selectedOrder}

--- a/src/components/container/categoryBookList/subCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/subCategoryBookList.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { getBook } from '@/api/book';
 import PreviewBookInfo from '@/components/book/previewBookInfo/previewBookInfo';
 import DropDown from '@/components/dropDown/dropDown';
-import SkeletonPreviewBookInfo from '@/components/skeleton/previewBookInfo/skeleton';
+import SkeletonPreviewBookImage from '@/components/skeleton/previewBookImage/skeleton';
 import useCarouselEnv from '@/hooks/useCarouselEnv';
 import useInfinite from '@/hooks/useInfinite';
 import useCustomInfiniteQuery from '@/hooks/useCustomInfiniteQuery';
@@ -90,7 +90,7 @@ function SubCategoryBookList() {
           className="grid min-h-400 w-[895px]
            grid-flow-row auto-rows-auto grid-cols-5 gap-x-20 gap-y-40 mobile:w-[330px] mobile:grid-cols-2 mobile:gap-y-0 tablet:w-[511px] tablet:grid-cols-3 ">
           {[0, 1, 2, 3, 4].map((el) => {
-            return <SkeletonPreviewBookInfo key={el} />;
+            return <SkeletonPreviewBookImage size="md" key={el} />;
           })}
         </div>
       )}

--- a/src/components/container/categoryBookList/subCategoryBookList.tsx
+++ b/src/components/container/categoryBookList/subCategoryBookList.tsx
@@ -8,9 +8,10 @@ import SkeletonPreviewBookInfo from '@/components/skeleton/previewBookInfo/skele
 import useCarouselEnv from '@/hooks/useCarouselEnv';
 import useInfinite from '@/hooks/useInfinite';
 import useCustomInfiniteQuery from '@/hooks/useCustomInfiniteQuery';
+import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
+import SelectOrder from '@/utils/selectOrder';
 
 import { BOOK_OLDER_STANDARD } from 'src/constants/orderList';
-import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
 
 const CURRENT_ORDER = {
   sort: 'VIEW',
@@ -48,34 +49,7 @@ function SubCategoryBookList() {
       });
     },
   });
-
-  const onSelectedOrder = (menu: string) => {
-    setSelectedOrder(menu);
-    if (menu === '조회순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'VIEW', ascending: false };
-      });
-    if (menu === '신상품순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'NEWEST', ascending: false };
-      });
-    if (menu === '별점순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'STAR', ascending: false };
-      });
-    if (menu === '리뷰 많은순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'REVIEW', ascending: false };
-      });
-    if (menu === '낮은 가격순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'PRICE', ascending: true };
-      });
-    if (menu === '높은 가격순')
-      setCurrentOrder((prev) => {
-        return { ...prev, sort: 'PRICE', ascending: false };
-      });
-  };
+  const onSelectedOrder = SelectOrder(setSelectedOrder, setCurrentOrder);
 
   return (
     <article className="relative flex h-fit flex-col gap-50 pb-30 mobile:gap-20 tablet:gap-40">
@@ -115,8 +89,7 @@ function SubCategoryBookList() {
         <div
           className="grid min-h-400 w-[895px]
            grid-flow-row auto-rows-auto grid-cols-5 gap-x-20 gap-y-40 mobile:w-[330px] mobile:grid-cols-2 mobile:gap-y-0 tablet:w-[511px] tablet:grid-cols-3 ">
-          {' '}
-          {[0, 1, 2].map((el) => {
+          {[0, 1, 2, 3, 4].map((el) => {
             return <SkeletonPreviewBookInfo key={el} />;
           })}
         </div>

--- a/src/hooks/useInitialParams.ts
+++ b/src/hooks/useInitialParams.ts
@@ -1,4 +1,4 @@
-import { SortType } from '@/types/api/book';
+import { BookParams, SortType } from '@/types/api/book';
 const INITIAL_LIMIT = '100';
 const INITIAL_ASCENDING = false;
 
@@ -11,4 +11,14 @@ const useInitialBestNewestParams = ({ sort }: SortType) => {
   return INITIAL_PARAMS;
 };
 
-export { useInitialBestNewestParams };
+const useCategoryCarouselParams = () => {
+  const INITIAL_PARAMS: BookParams = {
+    bookId: "0",
+    limit: "15",
+    sort: "NEWEST",
+    ascending: false,
+  }
+  return INITIAL_PARAMS;
+}
+
+export { useInitialBestNewestParams, useCategoryCarouselParams };

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -27,21 +27,27 @@ function CategoryPage() {
         eventSizeClassName="w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90"
       />
       <Spacing height={[60, 40, 40]} />
-      {data ? (
-        <CategoryCarousel data={data?.data.books} responsive={responsive} />
-      ) : null}
-      <Spacing height={[120, 80, 80]} />
+      {data && data?.data.books.length > 0 ? (
+        <>
+          <CategoryCarousel data={data?.data.books} responsive={responsive} />
+          <Spacing height={[120, 80, 80]} />
 
-      <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
-        <h1 className="text-20 text-black">베스트셀러</h1>
-        <div
-          role="temp"
-          className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
+          <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
+            <h1 className="text-20 text-black">베스트셀러</h1>
+            <div
+              role="temp"
+              className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
             tablet:w-[511px]"></div>
-      </article>
-      <Spacing height={[120, 80, 80]} />
+          </article>
+          <Spacing height={[120, 80, 80]} />
 
-      <SubCategoryBookList />
+          <SubCategoryBookList />
+        </>
+      ) : (
+        <div className="flex-center w-full pt-120 text-gray-4">
+          이 카테고리에 등록된 도서가 없어요!
+        </div>
+      )}
     </SidebarLayout>
   );
 }

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -44,7 +44,7 @@ function CategoryPage() {
           <SubCategoryBookList />
         </>
       ) : (
-        <div className="flex-center w-full pt-120 text-gray-4">
+        <div className="flex-center w-full pt-120 text-gray-4 mobile:pt-80">
           이 카테고리에 등록된 도서가 없어요!
         </div>
       )}

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -1,33 +1,48 @@
+import { useGetBook } from '@/api/book';
 import SidebarLayout from '@/components/layout/sidebarLayout';
 import Spacing from '@/components/container/spacing/spacing';
 import EventSection from '@/components/container/eventSection/eventSection';
 import CategoryCarousel from '@/components/carousel/categoryCarousel';
-import { carouselMockData } from '@/pages/api/mock/carouselMock';
-import { responsive } from '@/utils/checkResponsiveEnv';
 import SubCategoryBookList from '@/components/container/categoryBookList/subCategoryBookList';
+import { useCategoryCarouselParams } from '@/hooks/useInitialParams';
+import { responsive } from '@/utils/checkResponsiveEnv';
+import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
 
 function CategoryPage() {
+  const INITIAL_PARAMS = useCategoryCarouselParams();
+  const { categoryId } = useCheckCategoryUrl();
+  const { data } = useGetBook({
+    endpoint: `${categoryId}/sub`,
+    params: {
+      ...INITIAL_PARAMS,
+    },
+  });
+
   return (
-      <SidebarLayout >
-        <Spacing height={[0, 0, 20]} />
+    <SidebarLayout>
+      <Spacing height={[0, 0, 20]} />
 
-        <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
-        <Spacing height={[60, 40, 40]} />
+      <EventSection
+        adsSizeClassName="w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178"
+        eventSizeClassName="w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90"
+      />
+      <Spacing height={[60, 40, 40]} />
+      {data ? (
+        <CategoryCarousel data={data?.data.books} responsive={responsive} />
+      ) : null}
+      <Spacing height={[120, 80, 80]} />
 
-        <CategoryCarousel data={carouselMockData} responsive={responsive} />
-        <Spacing height={[120, 80, 80]} />
-
-        <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
-          <h1 className="text-20 text-black">베스트셀러</h1>
-          <div
-            role="temp"
-            className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
+      <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
+        <h1 className="text-20 text-black">베스트셀러</h1>
+        <div
+          role="temp"
+          className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
             tablet:w-[511px]"></div>
-        </article>        
-        <Spacing height={[120, 80, 80]} />
+      </article>
+      <Spacing height={[120, 80, 80]} />
 
-        <SubCategoryBookList />
-      </SidebarLayout>
+      <SubCategoryBookList />
+    </SidebarLayout>
   );
 }
 

--- a/src/pages/domestic/index.tsx
+++ b/src/pages/domestic/index.tsx
@@ -1,16 +1,23 @@
 /** 카테고리 페이지 > 국내 > 전체*/
 
+import { useGetBook } from '@/api/book';
 import SidebarLayout from '@/components/layout/sidebarLayout';
 import Spacing from '@/components/container/spacing/spacing';
 import CategoryCarousel from '@/components/carousel/categoryCarousel';
 import MainCategoryBookList from '@/components/container/categoryBookList/mainCategoryBookList';
 import EventSection from '@/components/container/eventSection/eventSection';
-
+import { useCategoryCarouselParams } from '@/hooks/useInitialParams';
 import { responsive } from '@/utils/checkResponsiveEnv';
 
-import { carouselMockData } from '../api/mock/carouselMock';
-
 export default function DomesticPage() {
+  const INITIAL_PARAMS = useCategoryCarouselParams();
+  const { data } = useGetBook({
+    endpoint: '0/main',
+    params: {
+      ...INITIAL_PARAMS,
+    },
+  });
+
   return (
     <SidebarLayout>
       <Spacing height={[0, 0, 20]} />
@@ -20,8 +27,9 @@ export default function DomesticPage() {
         eventSizeClassName="w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90"
       />
       <Spacing height={[60, 40, 40]} />
-
-      <CategoryCarousel data={carouselMockData} responsive={responsive} />
+      {data ? (
+        <CategoryCarousel data={data?.data.books} responsive={responsive} />
+      ) : null}
       <Spacing height={[120, 80, 80]} />
 
       <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -17,7 +17,6 @@ function CategoryPage() {
       ...INITIAL_PARAMS,
     },
   });
-  console.log(data);
 
   return (
     <SidebarLayout>
@@ -42,7 +41,7 @@ function CategoryPage() {
           <SubCategoryBookList />
         </>
       ) : (
-        <div className="flex-center w-full pt-120 text-gray-4">
+        <div className="flex-center w-full pt-120 text-gray-4 mobile:pt-80">
           이 카테고리에 등록된 도서가 없어요!
         </div>
       )}

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -1,33 +1,45 @@
+import { useGetBook } from '@/api/book';
 import SidebarLayout from '@/components/layout/sidebarLayout';
 import Spacing from '@/components/container/spacing/spacing';
 import EventSection from '@/components/container/eventSection/eventSection';
 import CategoryCarousel from '@/components/carousel/categoryCarousel';
-import { carouselMockData } from '@/pages/api/mock/carouselMock';
-import { responsive } from '@/utils/checkResponsiveEnv';
 import SubCategoryBookList from '@/components/container/categoryBookList/subCategoryBookList';
+import { useCategoryCarouselParams } from '@/hooks/useInitialParams';
+import useCheckCategoryUrl from '@/hooks/useCheckCategoryUrl';
+import { responsive } from '@/utils/checkResponsiveEnv';
 
 function CategoryPage() {
+  const INITIAL_PARAMS = useCategoryCarouselParams();
+  const { categoryId } = useCheckCategoryUrl();
+  const { data } = useGetBook({
+    endpoint: `${categoryId}/sub`,
+    params: {
+      ...INITIAL_PARAMS,
+    },
+  });
+
   return (
-      <SidebarLayout >
-        <Spacing height={[0, 0, 20]} />
-
-        <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
-        <Spacing height={[60, 40, 40]} />
-
-        <CategoryCarousel data={carouselMockData} responsive={responsive} />
-        <Spacing height={[120, 80, 80]} />
-
-        <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
-          <h1 className="text-20 text-black">베스트셀러</h1>
-          <div
-            role="temp"
-            className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
-            tablet:w-[511px]"></div>
-        </article>        
+    <SidebarLayout>
+      <Spacing height={[0, 0, 20]} />
+      <EventSection
+        adsSizeClassName="w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178"
+        eventSizeClassName="w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90"
+      />
+      <Spacing height={[60, 40, 40]} />
+      {data ? (
+        <CategoryCarousel data={data?.data.books} responsive={responsive} />
+      ) : null}
       <Spacing height={[120, 80, 80]} />
-      
-        <SubCategoryBookList />
-      </SidebarLayout>
+      <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
+        <h1 className="text-20 text-black">베스트셀러</h1>
+        <div
+          role="temp"
+          className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
+            tablet:w-[511px]"></div>
+      </article>
+      <Spacing height={[120, 80, 80]} />
+      <SubCategoryBookList />
+    </SidebarLayout>
   );
 }
 

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -17,6 +17,7 @@ function CategoryPage() {
       ...INITIAL_PARAMS,
     },
   });
+  console.log(data);
 
   return (
     <SidebarLayout>
@@ -25,20 +26,26 @@ function CategoryPage() {
         adsSizeClassName="w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178"
         eventSizeClassName="w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90"
       />
-      <Spacing height={[60, 40, 40]} />
-      {data ? (
-        <CategoryCarousel data={data?.data.books} responsive={responsive} />
-      ) : null}
-      <Spacing height={[120, 80, 80]} />
-      <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
-        <h1 className="text-20 text-black">베스트셀러</h1>
-        <div
-          role="temp"
-          className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
+      {data && data?.data.books.length > 0 ? (
+        <>
+          <Spacing height={[60, 40, 40]} />
+          <CategoryCarousel data={data?.data.books} responsive={responsive} />
+          <Spacing height={[120, 80, 80]} />
+          <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
+            <h1 className="text-20 text-black">베스트셀러</h1>
+            <div
+              role="temp"
+              className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
             tablet:w-[511px]"></div>
-      </article>
-      <Spacing height={[120, 80, 80]} />
-      <SubCategoryBookList />
+          </article>
+          <Spacing height={[120, 80, 80]} />
+          <SubCategoryBookList />
+        </>
+      ) : (
+        <div className="flex-center w-full pt-120 text-gray-4">
+          이 카테고리에 등록된 도서가 없어요!
+        </div>
+      )}
     </SidebarLayout>
   );
 }

--- a/src/pages/foreign/index.tsx
+++ b/src/pages/foreign/index.tsx
@@ -8,29 +8,43 @@ import EventSection from '@/components/container/eventSection/eventSection';
 
 import { responsive } from '@/utils/checkResponsiveEnv';
 
-import { carouselMockData } from '../api/mock/carouselMock';
+import { useCategoryCarouselParams } from '@/hooks/useInitialParams';
+import { useGetBook } from '@/api/book';
 
-export default function DomesticPage() {
+export default function ForeignPage() {
+  const INITIAL_PARAMS = useCategoryCarouselParams();
+  const { data } = useGetBook({
+    endpoint: `1/main`,
+    params: {
+      ...INITIAL_PARAMS,
+    },
+  });
+
   return (
-      <SidebarLayout >
-        <Spacing height={[0, 0, 20]} />
+    <SidebarLayout>
+      <Spacing height={[0, 0, 20]} />
 
-        <EventSection adsSizeClassName='w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178' eventSizeClassName='w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90'/>
-        <Spacing height={[60, 40, 40]} />
+      <EventSection
+        adsSizeClassName="w-[525px] h-[483px] tablet:w-297 tablet:h-275 mobile:w-330 mobile:h-178"
+        eventSizeClassName="w-[340px] h-[483px] tablet:w-194 tablet:h-275 mobile:w-330 mobile:h-90"
+      />
+      <Spacing height={[60, 40, 40]} />
 
-        <CategoryCarousel data={carouselMockData} responsive={responsive} />
-        <Spacing height={[120, 80, 80]} />
+      {data ? (
+        <CategoryCarousel data={data?.data.books} responsive={responsive} />
+      ) : null}
+      <Spacing height={[120, 80, 80]} />
 
-        <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
-          <h1 className="text-20 text-black">베스트셀러</h1>
-          <div
-            role="temp"
-            className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
+      <article className="flex flex-col gap-50 mobile:gap-20 tablet:gap-40">
+        <h1 className="text-20 text-black">베스트셀러</h1>
+        <div
+          role="temp"
+          className="h-[500px] w-[895px] bg-gray-1 mobile:w-[330px]
             tablet:w-[511px]"></div>
-        </article>        
-        <Spacing height={[120, 80, 80]} />
+      </article>
+      <Spacing height={[120, 80, 80]} />
 
-        <MainCategoryBookList />
-      </SidebarLayout>
+      <MainCategoryBookList />
+    </SidebarLayout>
   );
 }

--- a/src/utils/selectOrder.ts
+++ b/src/utils/selectOrder.ts
@@ -1,0 +1,36 @@
+function SelectOrder(
+  setSelectedOrder: (menu: string) => void,
+  setCurrentOrder: any,
+  ) {
+  const onSelectedOrder = (menu: string) => {
+    setSelectedOrder(menu);
+    if (menu === '조회순')
+      setCurrentOrder(() => {
+        return {sort: 'VIEW', ascending: false };
+      });
+    if (menu === '신상품순')
+      setCurrentOrder(() => {
+        return { sort: 'NEWEST', ascending: false };
+      });
+    if (menu === '별점순')
+      setCurrentOrder(() => {
+        return { sort: 'STAR', ascending: false };
+      });
+    if (menu === '리뷰 많은순')
+      setCurrentOrder(() => {
+        return { sort: 'REVIEW', ascending: false };
+      });
+    if (menu === '낮은 가격순')
+      setCurrentOrder(() => {
+        return { sort: 'PRICE', ascending: true };
+      });
+    if (menu === '높은 가격순')
+      setCurrentOrder(() => {
+        return { sort: 'PRICE', ascending: false };
+      });
+  };
+  
+  return onSelectedOrder
+}
+  
+export default SelectOrder;


### PR DESCRIPTION
## 구현사항

1.  카테고리 페이지 내부 신간 캐러셀 api 연결
2. 카테고리 페이지 스켈레톤 ui 추가
3. 카테고리 페이지 도서 없을 시 "카테고리에 도서가 없어요!" 문구 보이게 추가
4. sidebar 링크 에러 수정 ( 베스트셀러 페이지에 있을 때 사이드바의 국내 /전체보기 버튼을 눌러도 그대로 베스트셀러 페이지에 남아있게 수정) 

-[] 구현한 내용 및 설명

localhost:3000 카테고리 페이지에 보면 확인할 수 있습니다!!! 디자인적인 변경은 거의 없습니다.

연아님께서 올리신 carousel 데이터 props 수정 사항이 머지되면 캐러셀도 바로 api 반영되게끔 보일 거예요!! 

## 사용방법

## 스크린샷

데이터 수가 적은 경우
![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/5aee231c-5480-4e75-bcb6-805c96c53a2f)

데이터가 아예 없는 경우
![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/aa192b71-16a4-4dbe-88c7-ea9fb6508269)

스켈레톤
![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/f947b2d5-0d2b-4e15-8943-1d9d331fefba)



##### close #247 
