### PR TITLE
[#305] 배송지 선택 라디오 버튼의 기본 배송지가 다시 클릭되지 않는 문제 해결

### DIFF
--- a/src/components/container/shippingAddressSection/shippingAddressSection.tsx
+++ b/src/components/container/shippingAddressSection/shippingAddressSection.tsx
@@ -14,8 +14,8 @@ TODO
 function ShippingAddressSection() {
   const [isDefault, setIsDefault] = useState(true);
 
-  const handleOptionChange = (event: { target: { value: string } }) => {
-    setIsDefault(event.target.value === 'default');
+  const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsDefault(event.target.id === 'defaultAddress');
   };
 
   return (


### PR DESCRIPTION
## 구현사항

#305 와 같은 문제가 있어 해결했습니다.

## 사용방법
order 페이지에서 확인 가능합니다.

## 스크린샷
변경 전

https://github.com/bookstore-README/front_bookstore-README/assets/119280160/9c2157b3-d872-4ca3-afcd-9ea4c72d4ff2




변경 후

https://github.com/bookstore-README/front_bookstore-README/assets/119280160/6e7eef66-e4ad-4490-9b59-9264258c85ea


##### close #
