### PR TITLE
[#309] 헤더 장바구니 api 연결

### DIFF
--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -25,7 +25,7 @@ function MainLayout({ children }: MainLayoutProps) {
     <>
       <Header
         isLoggedIn={status === 'authenticated'}
-        numItemsOfCart={data.length} // basketItems의 길이로 업데이트
+        numItemsOfCart={data?.length} // basketItems의 길이로 업데이트
       />
       <div className="relative grid auto-rows-auto place-items-center">
         <div className="h-20 w-300" ref={ref} />

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -1,10 +1,11 @@
 import Header from '@/components/header/index';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect } from 'react';
 import ScrollToTopButton from '@/components/button/scrollToTopButton';
 import useInfinite from '@/hooks/useInfinite';
 import { useAtom } from 'jotai';
-import { pointVisibleAtom } from '@/store/state';
+import { pointVisibleAtom } from '@/store/state'; // basketItemList 추가
 import { useSession } from 'next-auth/react';
+import useGetBasKetQuery from '@/hooks/useGetBasKetQuery';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -14,6 +15,7 @@ function MainLayout({ children }: MainLayoutProps) {
   const [ref, isIntersecting] = useInfinite();
   const [, setPointVisible] = useAtom(pointVisibleAtom);
   const { status } = useSession();
+  const { data } = useGetBasKetQuery();
 
   useEffect(() => {
     setPointVisible(isIntersecting);
@@ -21,7 +23,10 @@ function MainLayout({ children }: MainLayoutProps) {
 
   return (
     <>
-      <Header isLoggedIn={status === 'authenticated'} numItemsOfCart={1} />
+      <Header
+        isLoggedIn={status === 'authenticated'}
+        numItemsOfCart={data.length} // basketItems의 길이로 업데이트
+      />
       <div className="relative grid auto-rows-auto place-items-center">
         <div className="h-20 w-300" ref={ref} />
         {children}


### PR DESCRIPTION
## 구현사항

- [x] 헤더 장바구니 api 연결해서 장바구니 물품 개수 표시
같은 물품을 여러 개 담아도 하나의 물품에 대한 개수는 1개로만 표시합니다 (알라딘도 그렇더라구용)

## 사용방법
[] 베스트/신간에서 장바구니 담기를 선택했을 때 헤더의 장바구니 위 숫자가 업데이트 되나요?
[] 장바구니 페이지 내부에서 물품을 삭제했을 때 헤더의 장바구니 위 숫자가 업데이트 되나요? (만약 안 된다면 https://github.com/bookstore-README/front_bookstore-README/pull/308 이 pr의 변경사항을 복붙해서 적용해보세요!)

## 스크린샷
<img width="1423" alt="스크린샷 2024-02-18 오후 12 41 03" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/b6abdf91-f549-4643-ba61-ce1196410a65">

영상 속 '일본어~~'의 경우 이미 담겨있는 책이라 헤더의 장바구니 개수가 업데이트 되지 않지만 장바구니 페이지에서는 수량이 업데이트 됩니당
https://github.com/bookstore-README/front_bookstore-README/assets/119280160/99eb034f-5434-48cf-a85d-3b92f0380167



##### close #309
