### PR TITLE
[#244] 제품상세페이지 구매하기, 장바구니 버튼 연결

### DIFF
--- a/src/api/basket.ts
+++ b/src/api/basket.ts
@@ -19,16 +19,16 @@ export const useGetCart = (memberId: number) => {
 };
 
 //장바구니 추가
-export const postBasket = async ({ bookId }: PostBasketParams) => {
-  const result = await instance.post(`/basket/${bookId}`);
+export const postBasket = async ({ bookId, count=1 }: PostBasketParams) => {
+  const result = await instance.post(`/basket/${bookId}?count=${count}`);
   return result.data;
 };
 
 export const usePostBasket = (
-  { bookId }: PostBasketParams,
+  { bookId,  count }: PostBasketParams,
   { onSuccess, onError, onSettled }: useUpdateType = {},
 ) => {
-  return useUpdate(postBasket, { bookId }, { onSuccess, onError, onSettled });
+  return useUpdate(postBasket, { bookId, count }, { onSuccess, onError, onSettled });
 };
 
 //장바구니 물건 삭제

--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -38,11 +38,11 @@ function BookDetailCard({
   setOrderCount,
 }: BookDetailCardProps) {
   return (
-    <section className="flex justify-start gap-20 items-start mobile:flex-col mobile:flex-center">
+    <section className="mobile:flex-center flex items-start justify-start gap-20 mobile:flex-col">
       <BookDetailImg imageUrl={bookImgUrl} />
       <article
         role="info"
-        className="flex flex-col gap-40 mobile:gap-30 justify-start items-start w-full max-w-[525px]">
+        className="flex w-full max-w-[525px] flex-col items-start justify-start gap-40 mobile:gap-30">
         <BookDetailInfo
           bookTitle={bookTitle}
           categories={categories}
@@ -57,6 +57,9 @@ function BookDetailCard({
         />
         <StaticOrderNavigator
           bookId={bookId}
+          bookImgUrl={bookImgUrl}
+          bookTitle={bookTitle}
+          authors={authors}
           price={price}
           orderCount={orderCount}
           setOrderCount={setOrderCount}

--- a/src/components/orderNavigator/footerOrderNavitgator.tsx
+++ b/src/components/orderNavigator/footerOrderNavitgator.tsx
@@ -1,11 +1,17 @@
 import { useState } from 'react';
-import OrderBookCount from '../cart/orderBookCount';
-import LikeButton from '../button/likeButton';
-import BookPrice from '../book/bookPrice/bookPrice';
+
+import OrderBookCount from '@/components/cart/orderBookCount';
+import LikeButton from '@/components/button/likeButton';
+import BookPrice from '@/components/book/bookPrice/bookPrice';
+import useAddItemBasket from '@/hooks/useAddItemBasket';
+import usePayNowItem from '@/hooks/usePayNowItem';
 
 interface SideOrderNavigatorProps {
   orderCount: number;
   setOrderCount: (s: number) => void;
+  bookImgUrl: string;
+  bookTitle: string;
+  authors: string[];
   price: number;
   bookId: string;
   isBookmarked: boolean;
@@ -16,18 +22,36 @@ function FooterOrderNavitgator({
   setOrderCount,
   price,
   bookId,
+  bookImgUrl,
+  bookTitle,
+  authors,
   isBookmarked,
 }: SideOrderNavigatorProps) {
   const [checkBookmarked, setIsBookmarked] = useState(isBookmarked || false);
+
+  // 구매하기 버튼 함수
+  const { handlePayNowButton } = usePayNowItem({
+    bookId: Number(bookId),
+    bookImgUrl,
+    bookTitle,
+    authors,
+    price,
+    count: orderCount,
+  });
+  //장바구니 버튼 함수
+  const { handleAddToBasket } = useAddItemBasket({
+    bookId: Number(bookId),
+    count: orderCount,
+  });
 
   const handleBookmarkClick = () => {
     setIsBookmarked(!checkBookmarked);
   };
   return (
     <div
-      className="pc:hidden flex justify-between w-full bg-white border-t-[1px] border-gray-5
-        sticky bottom-0 h-70 z-10 px-40 py-10 mobile:px-15">
-      <div className="flex items-center gap-18 justify-between">
+      className="sticky bottom-0 z-10 flex h-70 w-full justify-between
+        border-t-[1px] border-gray-5 bg-white px-40 py-10 mobile:px-15 pc:hidden">
+      <div className="flex items-center justify-between gap-18">
         <div>
           <OrderBookCount
             count={orderCount}
@@ -39,8 +63,8 @@ function FooterOrderNavitgator({
         </div>
         <BookPrice isBold fontSize={20} price={price * orderCount} hasUnit />
       </div>
-      <div className="flex justify-end items-center gap-10 grow">
-        <div className="mobile:hidden w-50 h-50 border-[1px] border-gray-5 rounded-[5px] flex-center">
+      <div className="flex grow items-center justify-end gap-10">
+        <div className="flex-center h-50 w-50 rounded-[5px] border-[1px] border-gray-5 mobile:hidden">
           <LikeButton
             isLiked={checkBookmarked}
             onClick={handleBookmarkClick}
@@ -49,13 +73,15 @@ function FooterOrderNavitgator({
           />
         </div>
         <button
-          className="mobile:hidden bg-white text-green border-2 border-green rounded-[5px] w-135 h-50
-            flex-center font-bold text-[17px]">
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-green bg-white text-[17px]
+            font-bold text-green mobile:hidden"
+          onClick={handleAddToBasket}>
           장바구니
         </button>
         <button
-          className="bg-green text-white border-2 border-green rounded-[5px] w-135 h-50 flex-center
-            font-bold text-[17px]">
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-green bg-green text-[17px]
+            font-bold text-white"
+          onClick={handlePayNowButton}>
           구매하기
         </button>
       </div>

--- a/src/components/orderNavigator/sideOrderNavigator.tsx
+++ b/src/components/orderNavigator/sideOrderNavigator.tsx
@@ -2,8 +2,14 @@ import { useState } from 'react';
 import BookPrice from '../book/bookPrice/bookPrice';
 import LikeButton from '../button/likeButton';
 import OrderBookCount from '../cart/orderBookCount';
+import usePayNowItem from '@/hooks/usePayNowItem';
+import useAddItemBasket from '@/hooks/useAddItemBasket';
 
 interface SideOrderNavigatorProps {
+  bookId: string;
+  bookImgUrl: string;
+  bookTitle: string;
+  authors: string[];
   orderCount: number;
   setOrderCount: (s: number) => void;
   price: number;
@@ -11,6 +17,10 @@ interface SideOrderNavigatorProps {
 }
 
 function SideOrderNavigator({
+  bookId,
+  bookImgUrl,
+  bookTitle,
+  authors,
   orderCount,
   setOrderCount,
   price,
@@ -18,13 +28,27 @@ function SideOrderNavigator({
 }: SideOrderNavigatorProps) {
   const [checkBookmarked, setIsBookmarked] = useState(isBookmarked || false);
 
+  // 구매하기 버튼 함수
+  const { handlePayNowButton } = usePayNowItem({
+    bookId: Number(bookId),
+    bookImgUrl,
+    bookTitle,
+    authors,
+    price,
+    count: orderCount,
+  });
+  //장바구니 버튼 함수
+  const { handleAddToBasket } = useAddItemBasket({
+    bookId: Number(bookId),
+    count: orderCount,
+  });
   const handleBookmarkClick = () => {
     setIsBookmarked(!checkBookmarked);
   };
   return (
     <div
-      className="bg-white mt-auto flex flex-col pc:w-340 gap-20 pc:h-164 pc:sticky pc:bottom-80
-        pc:right-60 z-50 bottom-0 left-0 right-0 w-full h-70">
+      className="bottom-0 left-0 right-0 z-50 mt-auto flex h-70 w-full flex-col
+        gap-20 bg-white pc:sticky pc:bottom-80 pc:right-60 pc:h-164 pc:w-340">
       <div className="flex justify-between">
         <span className="text-17 font-bold">수량</span>
         <OrderBookCount
@@ -39,8 +63,8 @@ function SideOrderNavigator({
         <span className="text-17 font-bold">총 금액</span>
         <BookPrice isBold fontSize={20} price={price * orderCount} hasUnit />
       </div>
-      <div className="flex-center gap-10 grow">
-        <div className="w-50 h-50 border-[1px] border-gray-5 rounded-[5px] flex-center">
+      <div className="flex-center grow gap-10">
+        <div className="flex-center h-50 w-50 rounded-[5px] border-[1px] border-gray-5">
           <LikeButton
             isLiked={checkBookmarked}
             onClick={handleBookmarkClick}
@@ -49,13 +73,15 @@ function SideOrderNavigator({
           />
         </div>
         <button
-          className="bg-white text-green border-2 border-green rounded-[5px] w-135 h-50 flex-center
-            font-bold text-[17px]">
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-green bg-white text-[17px]
+            font-bold text-green"
+          onClick={handleAddToBasket}>
           장바구니
         </button>
         <button
-          className="bg-green text-white border-2 border-green rounded-[5px] w-135 h-50 flex-center
-            font-bold text-[17px]">
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-green bg-green text-[17px]
+            font-bold text-white"
+          onClick={handlePayNowButton}>
           구매하기
         </button>
       </div>

--- a/src/components/orderNavigator/sideOrderNavigator.tsx
+++ b/src/components/orderNavigator/sideOrderNavigator.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import BookPrice from '../book/bookPrice/bookPrice';
-import LikeButton from '../button/likeButton';
-import OrderBookCount from '../cart/orderBookCount';
+
+import BookPrice from '@/components/book/bookPrice/bookPrice';
+import LikeButton from '@/components/button/likeButton';
+import OrderBookCount from '@/components/cart/orderBookCount';
 import usePayNowItem from '@/hooks/usePayNowItem';
 import useAddItemBasket from '@/hooks/useAddItemBasket';
 

--- a/src/components/orderNavigator/staticOrderNavigator.tsx
+++ b/src/components/orderNavigator/staticOrderNavigator.tsx
@@ -1,23 +1,46 @@
-import BookPrice from '../book/bookPrice/bookPrice';
-import OrderBookCount from '../cart/orderBookCount';
+import BookPrice from '@/components/book/bookPrice/bookPrice';
+import OrderBookCount from '@/components/cart/orderBookCount';
+import usePayNowItem from '@/hooks/usePayNowItem';
+import useAddItemBasket from '@/hooks/useAddItemBasket';
 
 /** 상품 상세페이지의 상품 정보 옆에 있는 구매하기 컴포넌트 */
 interface OrderNavigatorProps {
   bookId: string;
   price: number;
+  bookImgUrl: string;
+  bookTitle: string;
+  authors: string[];
   orderCount: number;
   setOrderCount: (s: number) => void;
 }
 function StaticOrderNavigator({
   orderCount,
   setOrderCount,
+  bookImgUrl,
+  bookTitle,
+  authors,
   price,
   bookId,
 }: OrderNavigatorProps) {
+  // 구매하기 버튼 함수
+  const { handlePayNowButton } = usePayNowItem({
+    bookId: Number(bookId),
+    bookImgUrl,
+    bookTitle,
+    authors,
+    price,
+    count: orderCount,
+  });
+  //장바구니 버튼 함수
+  const { handleAddToBasket } = useAddItemBasket({
+    bookId: Number(bookId),
+    count: orderCount,
+  });
+
   return (
     <div
-      className="bg-gray-5 rounded-[10px] p-20 w-full max-w-[525px] min-w-[525px] h-154 tablet:h-150 tablet:min-w-330
-        mobile:min-w-330 mobile:h-130 mobile:mx-auto flex flex-col gap-20 mobile:p-15 mobile:gap-10">
+      className="flex h-154 w-full min-w-[525px] max-w-[525px] flex-col gap-20 rounded-[10px] bg-gray-5
+        p-20 mobile:mx-auto mobile:h-130 mobile:min-w-330 mobile:gap-10 mobile:p-15 tablet:h-150 tablet:min-w-330">
       <div className="flex justify-between">
         <OrderBookCount
           count={orderCount}
@@ -28,15 +51,17 @@ function StaticOrderNavigator({
         />
         <BookPrice isBold fontSize={20} price={price * orderCount} hasUnit />
       </div>
-      <div className="flex-center gap-10 grow">
+      <div className="flex-center grow gap-10">
         <button
-          className="bg-white text-green border-2 border-green rounded-[5px] w-full h-54 flex-center
-            font-bold text-[17px]">
+          className="flex-center h-54 w-full rounded-[5px] border-2 border-green bg-white text-[17px]
+            font-bold text-green"
+          onClick={handleAddToBasket}>
           장바구니
         </button>
         <button
-          className="bg-green text-white border-2 border-green rounded-[5px] w-full h-54 flex-center
-            font-bold text-[17px]">
+          className="flex-center h-54 w-full rounded-[5px] border-2 border-green bg-green text-[17px]
+            font-bold text-white"
+          onClick={handlePayNowButton}>
           구매하기
         </button>
       </div>

--- a/src/hooks/useAddItemBasket.ts
+++ b/src/hooks/useAddItemBasket.ts
@@ -1,0 +1,22 @@
+// 장바구니 담기 버튼 로직
+import { useAddToBasket } from './api/useAddToBasket';
+
+interface AddItemBasketProps {
+  bookId: number;
+  count?: number;
+}
+
+function useAddItemBasket({bookId, count = 1}: AddItemBasketProps ) {
+    // 장바구니 버튼 로직
+  const { addToBasket } = useAddToBasket({
+    bookId: bookId,
+    count: count,
+  });
+
+  const handleAddToBasket = async () => {
+    addToBasket();
+  };
+  return { handleAddToBasket };
+}
+
+export default useAddItemBasket

--- a/src/hooks/usePayNowItem.ts
+++ b/src/hooks/usePayNowItem.ts
@@ -1,0 +1,40 @@
+// 구매하기 버튼 로직.
+
+import { useAtom } from "jotai";
+import { useRouter } from "next/router";
+
+import { PayMentAtom } from "@/types/cartType";
+import { basketItemList } from "@/store/state";
+
+interface PayNowItemProps{
+  bookId: number;
+  bookImgUrl: string;
+  bookTitle: string;
+  price: number;
+  authors: string[];
+  count?: number;
+}
+
+function usePayNowItem({bookId, bookImgUrl, bookTitle, price, authors, count=1}: PayNowItemProps) {
+  const [, setNowPayItem] = useAtom(basketItemList);
+  const router = useRouter();
+  const setNowPayItemList: PayMentAtom[] = [
+    {
+      basketId: bookId,
+      bookImgUrl: bookImgUrl,
+      bookTitle: bookTitle,
+      price: price,
+      authors: authors,
+      clicked: count,
+    },
+  ];
+
+  const handlePayNowButton = () => {
+    setNowPayItem(setNowPayItemList);
+    router.push('/order');
+  };
+
+  return {handlePayNowButton}
+}
+
+export default usePayNowItem

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -92,9 +92,12 @@ export default function BookDetailPage() {
         </section>
 
         <FooterOrderNavitgator
+          bookId={bookId as string}
+          bookImgUrl={data?.data.bookImgUrl ?? '/.'}
+          bookTitle={data?.data.bookTitle}
+          authors={data?.data.authors}
           isBookmarked={false}
           price={data?.data.price ?? 0}
-          bookId={bookId as string}
           orderCount={orderCount}
           setOrderCount={setOrderCount}
         />

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -79,6 +79,10 @@ export default function BookDetailPage() {
 
           <div className="hidden pc:flex pc:pt-50">
             <SideOrderNavigator
+              bookId={bookId as string}
+              bookImgUrl={data?.data.bookImgUrl ?? '/.'}
+              bookTitle={data?.data.bookTitle}
+              authors={data?.data.authors}
               isBookmarked={false}
               price={data?.data.price ?? 0}
               orderCount={orderCount}

--- a/src/types/api/basket.ts
+++ b/src/types/api/basket.ts
@@ -1,3 +1,4 @@
 export interface PostBasketParams {
   bookId: number;
+  count?: number;
 }


### PR DESCRIPTION
## 구현사항

(브랜치 명은 실수...)

제품상세페이지 내부 장바구니, 구매하기 버튼 api 연결했습니다!!
페이지 안에 동일한 버튼이 3개씩 있어서, 버튼 onClick 로직을 그냥 훅으로 빼버렸습니다. 

-[] 구현한 내용 및 설명

1. staticOrder 컴포넌트의 장바구니, 구매하기 버튼 api 연결
2. sideOrder 컴포넌트의 장바구니, 구매하기 버튼 api  연결
3. footerOrder 컴포넌트의 장바구니, 구매하기 버튼 api 연결
4. 구매, 장바구니 버튼 onClick 메소드를 훅으로 따로 뺌
5. postBasket api 함수에 책 수량 속성 추가. (옵셔널로 해둬서 수량 지정 안하면 그냥 1권으로 지정됨.)

## 사용방법

bookdetail 페이지로 가서 staticOrder, sideOrder, footerOrder 컴포넌트 각각의 장바구니 구매하기 버튼 클릭해보기.
장바구니 버튼을 클릭하면 토스트 메세지가 뜨면서 장바구니에 아이템이 수량만큼 담김
구매하기 버튼을 클릭하면 바로 order 페이지로 넘어감.

## 스크린샷

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/a23b2ef3-1bb2-458d-a688-1b876433c6e2)

##### close #244
