### PR TITLE
[#239] 베스트/신간 페이지 찜하기 api 연결(도움필요!!)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "classnames": "^2.5.1",
         "install": "^0.13.0",
         "jotai": "^2.6.2",
+        "lodash": "^4.17.21",
         "next": "14.1.0",
         "next-auth": "^4.24.6",
         "prettier-plugin-tailwindcss": "^0.5.11",
@@ -24,6 +25,7 @@
         "react-toastify": "^10.0.4"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.202",
         "@types/node": "^20",
         "@types/react": "^18.2.48",
         "@types/react-datepicker": "^4.19.5",
@@ -543,6 +545,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3214,6 +3222,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "classnames": "^2.5.1",
         "install": "^0.13.0",
         "jotai": "^2.6.2",
-        "lodash": "^4.17.21",
         "next": "14.1.0",
         "next-auth": "^4.24.6",
         "prettier-plugin-tailwindcss": "^0.5.11",
@@ -3222,11 +3221,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "classnames": "^2.5.1",
     "install": "^0.13.0",
     "jotai": "^2.6.2",
+    "lodash": "^4.17.21",
     "next": "14.1.0",
     "next-auth": "^4.24.6",
     "prettier-plugin-tailwindcss": "^0.5.11",
@@ -25,6 +26,7 @@
     "react-toastify": "^10.0.4"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.202",
     "@types/node": "^20",
     "@types/react": "^18.2.48",
     "@types/react-datepicker": "^4.19.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "classnames": "^2.5.1",
     "install": "^0.13.0",
     "jotai": "^2.6.2",
-    "lodash": "^4.17.21",
     "next": "14.1.0",
     "next-auth": "^4.24.6",
     "prettier-plugin-tailwindcss": "^0.5.11",

--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -1,5 +1,10 @@
 import { BookmarkParams, postBookmarkPath } from '@/types/api/bookmark';
-import { useDelete, useFetch, useUpdate } from '@/utils/reactQuery';
+import {
+  useDelete,
+  useFetch,
+  useUpdate,
+  useUpdateType,
+} from '@/utils/reactQuery';
 import { QUERY_KEY } from 'src/constants/queryKey';
 import { instance } from 'src/libs/instance';
 
@@ -33,14 +38,21 @@ export const useGetOptionBookmark = (option: {
 };
 
 //찜 하기
-const postBookmark = async (option: postBookmarkPath) => {
-  const { bookId, memberId } = option;
-  const result = await instance.post(`/bookmark/${bookId}/${memberId}`);
+const postBookmark = async (bookId: number) => {
+  const result = await instance.post(`/bookmark/${bookId}`);
   return result.data.data;
 };
 
-export const usePostBookmark = (option: postBookmarkPath) => {
-  return useUpdate(postBookmark, option);
+export const usePostBookmark = (
+  bookId: number,
+  { onSuccess, onError, onSettled, onMutate }: useUpdateType = {},
+) => {
+  return useUpdate(postBookmark, bookId, {
+    onSuccess,
+    onError,
+    onSettled,
+    onMutate,
+  });
 };
 
 //찜 삭제

--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -38,7 +38,7 @@ export const useGetOptionBookmark = (option: {
 };
 
 //찜 하기
-const postBookmark = async (bookId: number) => {
+export const postBookmark = async (bookId: number) => {
   const result = await instance.post(`/bookmark/${bookId}`);
   return result.data.data;
 };

--- a/src/components/button/likeButton.tsx
+++ b/src/components/button/likeButton.tsx
@@ -7,11 +7,18 @@ interface LikeButtonProps {
   isLiked: boolean;
   width?: number;
   height?: number;
+  disabled?: boolean;
 }
 
-function LikeButton({ onClick, isLiked, width, height }: LikeButtonProps) {
+function LikeButton({
+  onClick,
+  isLiked,
+  width,
+  height,
+  disabled,
+}: LikeButtonProps) {
   return (
-    <button onClick={onClick}>
+    <button onClick={onClick} disabled={disabled}>
       <Image
         src={isLiked ? HeartFillIcon : HeartEmptyIcon}
         alt="좋아요 이미지"

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -26,8 +26,14 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   });
 
   const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
-    bookId: book.bookId,
-    onChangeBookmarkCount: (prevCount) => setBookmarkCount(prevCount),
+    bookId: 42423431,
+    onChangeBookmarkCount: () => {
+      if (isBookmarked) {
+        setBookmarkCount((prev) => prev - 1);
+      } else {
+        setBookmarkCount((prev) => prev + 1);
+      }
+    },
     onChangeBookmarked: (prevState) => setIsBookMarked(prevState),
   });
 
@@ -54,11 +60,6 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     setNowPayItem(setNowPayItemList);
     router.push('/order');
   };
-
-  // 최신 isBookmarked 상태를 useUpdateBookmark에 넘겨주기 위한 useEffect
-  useEffect(() => {
-    setIsBookMarked(isBookmarked);
-  }, [isBookmarked]);
 
   return (
     <div

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -14,15 +14,17 @@ import MobileBookOverViewCard from './bookOverviewMobile';
 import { useSetAtom } from 'jotai';
 import { CartItem } from '@/types/cartType';
 import { basketItemList } from '@/store/state';
+import { useUpdateBookmark } from '@/hooks/api/useUpdateBookmark';
 
 function BookOverviewCard({ book, rank }: BookOverviewType2) {
-  const [isLiked, setIsLiked] = useState(book.bookmarks?.marked);
-  const [likeCount, setIsLikeCount] = useState(book.bookmarkCount);
+  const [isBookmarked, setIsBookMarked] = useState(book.bookmarks?.marked);
+  const [bookmarkCount, setBookmarkCount] = useState(book.bookmarkCount);
   const router = useRouter();
   const formattedDate = formatDate(book.publishedDate);
   const { addToBasket, isAddToBasketPending } = useAddToBasket({
     bookId: book.bookId,
   });
+  const { updateBookmark, isBookmarkPending } = useUpdateBookmark(book.bookId);
 
   const setNowPayItem = useSetAtom(basketItemList);
   const setNowPayItemList: CartItem[] = [
@@ -36,9 +38,12 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     },
   ];
   const handleAddToBookmark = () => {
-    // setIsLiked(!isLiked);
-    // if (!isLiked) setIsLikeCount((prevCount) => prevCount + 1);
-    // else setIsLikeCount((prevCount) => prevCount - 1);
+    setIsBookMarked(!isBookmarked);
+    isBookmarked
+      ? setBookmarkCount((prevCount) => prevCount - 1)
+      : setBookmarkCount((prevCount) => prevCount + 1);
+
+    updateBookmark();
   };
 
   const handleAddToBasket = async () => {
@@ -134,8 +139,12 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
           className="flex flex-col items-end gap-30 mobile:absolute mobile:bottom-16 mobile:right-0
             tablet:absolute tablet:right-0">
           <div role="like-button" className="flex-center flex-col gap-2">
-            <LikeButton onClick={handleAddToBookmark} isLiked={isLiked} />
-            <span className="text-12 text-black">{likeCount}</span>
+            <LikeButton
+              onClick={handleAddToBookmark}
+              isLiked={isBookmarked}
+              disabled={isBookmarkPending}
+            />
+            <span className="text-12 text-black">{bookmarkCount}</span>
           </div>
           <div
             role="cart-button"

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -26,7 +26,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   });
 
   const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
-    bookId: 42423431,
+    bookId: book.bookId,
     onChangeBookmarkCount: () => {
       if (isBookmarked) {
         setBookmarkCount((prev) => prev - 1);

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -1,7 +1,7 @@
 import { BookOverviewType2 } from '@/types/bookOverviewType';
 import { THOUSAND_UNIT } from 'src/constants/price';
 import LikeButton from '@/components/button/likeButton';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import BookRating from '@/components/book/bookRating/bookRating';
 import ActionButton from '@/components/button/actionButton';
 import Link from 'next/link';
@@ -24,15 +24,9 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const { addToBasket, isAddToBasketPending } = useAddToBasket({
     bookId: book.bookId,
   });
-  //  const handleBookmarkChange = (isBookmarked:boolean) => {
-  //    if (isBookmarked) {
-  //      setBookmarkCount(bookmarkCount + 1);
-  //    } else {
-  //      setBookmarkCount(bookmarkCount - 1);
-  //    }
-  //  };
+
   const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
-    bookId: 23424242,
+    bookId: book.bookId,
     onChangeBookmarkCount: (prevCount) => setBookmarkCount(prevCount),
     onChangeBookmarked: (prevState) => setIsBookMarked(prevState),
   });
@@ -49,10 +43,6 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     },
   ];
   const handleAddToBookmark = () => {
-    setIsBookMarked(!isBookmarked);
-    isBookmarked
-      ? setBookmarkCount((prevCount) => prevCount - 1)
-      : setBookmarkCount((prevCount) => prevCount + 1);
     updateBookmark();
   };
 
@@ -64,6 +54,11 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     setNowPayItem(setNowPayItemList);
     router.push('/order');
   };
+
+  // 최신 isBookmarked 상태를 useUpdateBookmark에 넘겨주기 위한 useEffect
+  useEffect(() => {
+    setIsBookMarked(isBookmarked);
+  }, [isBookmarked]);
 
   return (
     <div

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -24,7 +24,18 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const { addToBasket, isAddToBasketPending } = useAddToBasket({
     bookId: book.bookId,
   });
-  const { updateBookmark, isBookmarkPending } = useUpdateBookmark(book.bookId);
+  //  const handleBookmarkChange = (isBookmarked:boolean) => {
+  //    if (isBookmarked) {
+  //      setBookmarkCount(bookmarkCount + 1);
+  //    } else {
+  //      setBookmarkCount(bookmarkCount - 1);
+  //    }
+  //  };
+  const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
+    bookId: 23424242,
+    onChangeBookmarkCount: (prevCount) => setBookmarkCount(prevCount),
+    onChangeBookmarked: (prevState) => setIsBookMarked(prevState),
+  });
 
   const setNowPayItem = useSetAtom(basketItemList);
   const setNowPayItemList: CartItem[] = [
@@ -42,11 +53,10 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     isBookmarked
       ? setBookmarkCount((prevCount) => prevCount - 1)
       : setBookmarkCount((prevCount) => prevCount + 1);
-
     updateBookmark();
   };
 
-  const handleAddToBasket = async () => {
+  const handleAddToBasket = () => {
     addToBasket();
   };
 
@@ -73,6 +83,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
             bookId={book.bookId}
           />
         </Link>
+        <div>{book.bookmarks?.marked}</div>
 
         <div
           role="book-info"

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -16,13 +16,14 @@ import { CartItem } from '@/types/cartType';
 import { basketItemList } from '@/store/state';
 
 function BookOverviewCard({ book, rank }: BookOverviewType2) {
-  const [isLiked, setIsLiked] = useState(false);
+  const [isLiked, setIsLiked] = useState(book.bookmarks?.marked);
   const [likeCount, setIsLikeCount] = useState(book.bookmarkCount);
   const router = useRouter();
   const formattedDate = formatDate(book.publishedDate);
   const { addToBasket, isAddToBasketPending } = useAddToBasket({
     bookId: book.bookId,
   });
+
   const setNowPayItem = useSetAtom(basketItemList);
   const setNowPayItemList: CartItem[] = [
     {
@@ -35,9 +36,9 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
     },
   ];
   const handleAddToBookmark = () => {
-    setIsLiked(!isLiked);
-    if (!isLiked) setIsLikeCount((prevCount) => prevCount + 1);
-    else setIsLikeCount((prevCount) => prevCount - 1);
+    // setIsLiked(!isLiked);
+    // if (!isLiked) setIsLikeCount((prevCount) => prevCount + 1);
+    // else setIsLikeCount((prevCount) => prevCount - 1);
   };
 
   const handleAddToBasket = async () => {
@@ -46,8 +47,6 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
 
   const handleAddForPayment = () => {
     setNowPayItem(setNowPayItemList);
-    //atom에 저장된거 확인했음!
-
     router.push('/order');
   };
 

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -1,10 +1,11 @@
 import Header from '@/components/header/index';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect } from 'react';
 import ScrollToTopButton from '@/components/button/scrollToTopButton';
 import useInfinite from '@/hooks/useInfinite';
 import { useAtom } from 'jotai';
-import { pointVisibleAtom } from '@/store/state';
+import { pointVisibleAtom } from '@/store/state'; // basketItemList 추가
 import { useSession } from 'next-auth/react';
+import useGetBasKetQuery from '@/hooks/useGetBasKetQuery';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -14,6 +15,7 @@ function MainLayout({ children }: MainLayoutProps) {
   const [ref, isIntersecting] = useInfinite();
   const [, setPointVisible] = useAtom(pointVisibleAtom);
   const { status } = useSession();
+  const { data } = useGetBasKetQuery();
 
   useEffect(() => {
     setPointVisible(isIntersecting);
@@ -21,7 +23,10 @@ function MainLayout({ children }: MainLayoutProps) {
 
   return (
     <>
-      <Header isLoggedIn={status === 'authenticated'} numItemsOfCart={1} />
+      <Header
+        isLoggedIn={status === 'authenticated'}
+        numItemsOfCart={data?.length} // basketItems의 길이로 업데이트
+      />
       <div className="relative grid auto-rows-auto place-items-center">
         <div className="h-20 w-300" ref={ref} />
         {children}

--- a/src/constants/userAction.ts
+++ b/src/constants/userAction.ts
@@ -1,0 +1,4 @@
+export const USER_ACTION = {
+  MARK_BOOK: 'marked',
+  UN_MARK_BOOK: 'unMarked',
+};

--- a/src/hooks/api/useUpdateBookmark.ts
+++ b/src/hooks/api/useUpdateBookmark.ts
@@ -2,14 +2,11 @@ import { usePostBookmark } from '@/api/bookmark';
 import { notify } from '@/components/toast/toast';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useQueryClient } from '@tanstack/react-query';
-import { throttle } from 'lodash';
 
 interface useUpdateBookmarkProps {
   bookId: number;
   onChangeBookmarked: (updateFunction: (prevState: boolean) => boolean) => void;
-  onChangeBookmarkCount: (
-    updateFunction: (prevCount: number) => number,
-  ) => void;
+  onChangeBookmarkCount: () => void;
 }
 
 export const useUpdateBookmark = ({
@@ -20,22 +17,10 @@ export const useUpdateBookmark = ({
   const queryClient = useQueryClient();
   const queryKey = [QUERY_KEY.bookmark];
 
-  // onChangeBookmarkCount 함수를 throttle 처리(1000ms 간격으로 제한)
-  const throttledOnChangeBookmarkCount = throttle((updateFunction) => {
-    onChangeBookmarkCount(updateFunction);
-  }, 1000);
-
   const { mutate, isPending } = usePostBookmark(bookId, {
     onMutate: async (bookId: number) => {
+      onChangeBookmarkCount();
       onChangeBookmarked((prevState) => {
-        if (!prevState) {
-          // 북마크가 설정되지 않은 경우에만 카운트 증가
-          throttledOnChangeBookmarkCount((prevCount: number) => prevCount + 1);
-        } else {
-          // 북마크가 설정된 경우에만 카운트 감소
-          throttledOnChangeBookmarkCount((prevCount: number) => prevCount - 1);
-        }
-        // 북마크 상태를 토글
         return !prevState;
       });
       await queryClient.cancelQueries({ queryKey: queryKey });
@@ -44,13 +29,8 @@ export const useUpdateBookmark = ({
       return { prevOption };
     },
     onError: (error, variables, context) => {
+      onChangeBookmarkCount();
       onChangeBookmarked((prevState) => {
-        // 에러 발생 시 이전 북마크 상태로 롤백
-        if (!prevState) {
-          throttledOnChangeBookmarkCount((prevCount: number) => prevCount + 1);
-        } else {
-          throttledOnChangeBookmarkCount((prevCount: number) => prevCount - 1);
-        }
         return !prevState;
       });
       if (context?.prevOption) {
@@ -62,7 +42,6 @@ export const useUpdateBookmark = ({
       });
     },
     onSuccess: () => {
-      // 쿼리 함수의 성공시 기존 데이터 무효화
       queryClient.invalidateQueries({ queryKey: queryKey });
     },
   });

--- a/src/hooks/api/useUpdateBookmark.ts
+++ b/src/hooks/api/useUpdateBookmark.ts
@@ -2,22 +2,61 @@ import { usePostBookmark } from '@/api/bookmark';
 import { notify } from '@/components/toast/toast';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useQueryClient } from '@tanstack/react-query';
+import { count } from 'console';
 // postBookmark 사용하여 찜하기 put 요청 보내기
 // 북마크 수정 쿼리
-export const useUpdateBookmark = (bookId: number) => {
+
+// useUpdateBookmark 프롭스로 isBookMarked, count 변경 setter 함수 받아오기
+// onMutate일떄 setter 함수 실행하기 (카운트+1, isBookMarked)
+// onError일때 setter 함수 실행하기 (카운트-1, !isBookMarked)
+
+interface useUpdateBookmarkProps {
+  bookId: number;
+  onChangeBookmarked: (updateFunction: (prevState: boolean) => boolean) => void;
+  onChangeBookmarkCount: (
+    updateFunction: (prevCount: number) => number,
+  ) => void;
+}
+
+export const useUpdateBookmark = ({
+  bookId,
+  onChangeBookmarked,
+  onChangeBookmarkCount,
+}: useUpdateBookmarkProps) => {
   const queryClient = useQueryClient();
   const queryKey = [QUERY_KEY.bookmark];
 
   const { mutate, isPending } = usePostBookmark(bookId, {
     onMutate: async (bookId: number) => {
+      // onChangeBookmarked((prevState) => {
+      //   if (!prevState) {
+      //     // 북마크가 설정되지 않은 경우에만 카운트 증가
+      //     onChangeBookmarkCount((prevCount) => prevCount + 1);
+      //   } else onChangeBookmarkCount((prevCount) => prevCount - 1);
+      //   // 북마크 상태를 토글
+      //   return !prevState;
+      // });
       await queryClient.cancelQueries();
       const prevOption = queryClient.getQueryData(queryKey);
       queryClient.setQueryData(queryKey, bookId);
       return { prevOption };
     },
-    onError: (context) => {
-      // 에러발생시 캐시를 저장된 값으로 롤백
-      queryClient.setQueryData(queryKey, context?.prevOption);
+    onError: (error, variables, context) => {
+      onChangeBookmarked((prevState) => {
+        // 에러 발생 시 이전 북마크 상태로 롤백하고, 카운트도 이전 상태에 맞게 조정합니다.
+        if (!prevState) {
+          console.log(prevState);
+          // 만약 북마크 설정이 취소되었다면, 카운트를 다시 증가시킵니다.
+          onChangeBookmarkCount((prevCount) => prevCount + 1);
+        } else {
+          // 만약 북마크가 새로 설정되었다면, 카운트를 다시 감소시킵니다.
+          onChangeBookmarkCount((prevCount) => prevCount - 1);
+        }
+        return !prevState;
+      });
+      if (context?.prevOption) {
+        queryClient.setQueryData(queryKey, context.prevOption);
+      }
       notify({
         type: 'error',
         text: '찜하기에 실패했어요 😫',

--- a/src/hooks/api/useUpdateBookmark.ts
+++ b/src/hooks/api/useUpdateBookmark.ts
@@ -1,0 +1,15 @@
+import { usePostBookmark } from '@/api/bookmark';
+import { notify } from '@/components/toast/toast';
+import { postBookmarkPath } from '@/types/api/bookmark';
+
+export const useUpdateBookmark = (bookId: number) => {
+  const { mutate, isPending } = usePostBookmark(bookId, {
+    onSuccess: () =>
+      notify({ type: 'success', text: '장바구니에 담았어요 🛒' }),
+    onError: () =>
+      notify({ type: 'error', text: '장바구니 담기에 실패했어요. 😭' }),
+  });
+
+  // mutate 함수와 pending 상태를 반환
+  return { addToBasket: mutate, isAddToBasketPending: isPending };
+};

--- a/src/hooks/api/useUpdateBookmark.ts
+++ b/src/hooks/api/useUpdateBookmark.ts
@@ -3,12 +3,6 @@ import { notify } from '@/components/toast/toast';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useQueryClient } from '@tanstack/react-query';
 import { count } from 'console';
-// postBookmark 사용하여 찜하기 put 요청 보내기
-// 북마크 수정 쿼리
-
-// useUpdateBookmark 프롭스로 isBookMarked, count 변경 setter 함수 받아오기
-// onMutate일떄 setter 함수 실행하기 (카운트+1, isBookMarked)
-// onError일때 setter 함수 실행하기 (카운트-1, !isBookMarked)
 
 interface useUpdateBookmarkProps {
   bookId: number;
@@ -28,14 +22,14 @@ export const useUpdateBookmark = ({
 
   const { mutate, isPending } = usePostBookmark(bookId, {
     onMutate: async (bookId: number) => {
-      // onChangeBookmarked((prevState) => {
-      //   if (!prevState) {
-      //     // 북마크가 설정되지 않은 경우에만 카운트 증가
-      //     onChangeBookmarkCount((prevCount) => prevCount + 1);
-      //   } else onChangeBookmarkCount((prevCount) => prevCount - 1);
-      //   // 북마크 상태를 토글
-      //   return !prevState;
-      // });
+      onChangeBookmarked((prevState) => {
+        if (!prevState) {
+          // 북마크가 설정되지 않은 경우에만 카운트 증가
+          onChangeBookmarkCount((prevCount) => prevCount + 1);
+        } else onChangeBookmarkCount((prevCount) => prevCount - 1);
+        // 북마크 상태를 토글
+        return !prevState;
+      });
       await queryClient.cancelQueries();
       const prevOption = queryClient.getQueryData(queryKey);
       queryClient.setQueryData(queryKey, bookId);
@@ -43,13 +37,10 @@ export const useUpdateBookmark = ({
     },
     onError: (error, variables, context) => {
       onChangeBookmarked((prevState) => {
-        // 에러 발생 시 이전 북마크 상태로 롤백하고, 카운트도 이전 상태에 맞게 조정합니다.
+        // 에러 발생 시 이전 북마크 상태로 롤백
         if (!prevState) {
-          console.log(prevState);
-          // 만약 북마크 설정이 취소되었다면, 카운트를 다시 증가시킵니다.
           onChangeBookmarkCount((prevCount) => prevCount + 1);
         } else {
-          // 만약 북마크가 새로 설정되었다면, 카운트를 다시 감소시킵니다.
           onChangeBookmarkCount((prevCount) => prevCount - 1);
         }
         return !prevState;

--- a/src/pages/cart/index.tsx
+++ b/src/pages/cart/index.tsx
@@ -63,16 +63,12 @@ function CartPage() {
   const filteredDataByNotTargetId = (arr: CartItem[], targetId: number) =>
     arr.filter((arrItem) => arrItem.basketId !== targetId);
 
-  const handleDeleteSelectedItems = () => {
+  const handleDeleteSelectedItems = async () => {
     const selectedBookMarkIds = selectedItemArr.map((item) => item.basketId);
-    deleteBasketItemMutation.mutate(selectedBookMarkIds.join(','));
-    const filteredData = wishListData.filter((item) => {
-      return (
-        selectedItemArr
-          .map((picked) => picked.basketId)
-          .indexOf(item.basketId) === -1
-      );
-    });
+    await deleteBasketItemMutation.mutateAsync(selectedBookMarkIds.join(','));
+    const filteredData = wishListData.filter(
+      (item) => !selectedBookMarkIds.includes(item.basketId),
+    );
     setWishListData(filteredData);
     resetSelectedItemArr();
   };

--- a/src/types/api/book.ts
+++ b/src/types/api/book.ts
@@ -22,7 +22,16 @@ export interface putBookPath {
   memberId: number;
 }
 
-export interface BookData {
+interface BookmarksType {
+  bookmarks: {
+    bookId: number;
+    bookmarkId: number;
+    marked: boolean;
+    memberId: number;
+  };
+}
+
+export interface BookData extends BookmarksType {
   bookId: number;
   bookTitle: string;
   description: string | null;

--- a/src/types/api/bookmark.ts
+++ b/src/types/api/bookmark.ts
@@ -7,5 +7,4 @@ export interface BookmarkParams {
 
 export interface postBookmarkPath {
   bookId: number;
-  memberId: number;
 }

--- a/src/utils/reactQuery.ts
+++ b/src/utils/reactQuery.ts
@@ -28,7 +28,7 @@ export const useDelete = <T>(
 
 export interface useUpdateType {
   onSuccess?: (data: any) => void;
-  onError?: (error: any) => void;
+  onError?: (error: any, variables?: any, context?: any) => void;
   onSettled?: (data?: any, error?: any) => void;
   onMutate?: (data?: any) => void;
 }
@@ -36,7 +36,6 @@ export const useUpdate = <T>(
   mutationFn: (option: T) => Promise<any>,
   option: T,
   { onSuccess, onError, onSettled, onMutate }: useUpdateType = {},
-
 ) => {
   const queryClient = useQueryClient();
   const mutation = useMutation({


### PR DESCRIPTION
## 구현사항

- 베스트/신간 페이지에 찜하기/찜취소 api를 연결했어요
***

## 수정된 사항
찜하기 실패시, ui와 카운트가 되돌아가도록 수정했습니다.
다만, 아직 카운트가 먼저 바뀌고 이미지가 그 후에 바뀌는 것은 수정하지 못했습니다..

***

## 수정된 사항2

~빠르게 찜버튼 클릭시 카운트가 +2 또는 -2씩 변하는 현상을 위해 **lodash를 설치**하여 throttle을 사용했습니다.~
불필요하다고 판단하여 다시 삭제하고 uninstall 해두었습니다.

## 사용방법

코드에 코멘트로 달겠습니다



### 문제점

#### 찜 카운트와 하트이미지의 적용 속도가 다름

https://github.com/bookstore-README/front_bookstore-README/assets/120437902/6d94f443-e0b7-4e22-ad1f-f724921072a7

<br>
<img width="330" alt="스크린샷 2024-02-18 오후 8 28 49" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/9484de11-b643-44d5-8fde-ac354d7cfa3b"><br>

isBookmarked 값이 변할떄마다 이미지를 계속 불러오는데, 
바로 숫자를 랜더링하는 count와 다르게 추가적인 시간이 드는것 같아요..
useMemo를 써봤는데 제가 잘못쓰는건지 해결을 못했어요 흙흙모래모래자갈자갈..
방법 아시는분 코멘트 부탁드립니다 ㅠㅠ

## 스크린샷

api 연결은 잘 되었습니당..

https://github.com/bookstore-README/front_bookstore-README/assets/120437902/5bb936d6-eaf4-407b-a83b-89e1eaf5633b





##### close #239 
##### close #315
