### PR TITLE
[#295] 제품 상세페이지 찜 버튼 구현 

### DIFF
--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -68,3 +68,13 @@ export const deleteBookMarkItem = async (bookmarkId: string) => {
 export const useDeleteBookmark = (bookmarkId: string) => {
   return useDelete(deleteBookmark, bookmarkId);
 };
+
+// 해당 책에 대한 찜 여부 조회
+const getIsBookmarked = async (bookId: string) => {
+  const result = await instance.get(`/bookmark/${bookId}/check`);
+  return result.data.data;
+};
+
+export const useGetIsBookmarked = ({ bookId="", enabled = true }) => {
+  return useFetch(QUERY_KEY.bookmark, getIsBookmarked, bookId, enabled);
+};

--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -1,4 +1,4 @@
-import { BookmarkParams, postBookmarkPath } from '@/types/api/bookmark';
+import { BookmarkParams, deleteBookmarkPath, postBookmarkPath } from '@/types/api/bookmark';
 import { useDelete, useFetch, useUpdate } from '@/utils/reactQuery';
 import { QUERY_KEY } from 'src/constants/queryKey';
 import { instance } from 'src/libs/instance';
@@ -34,13 +34,13 @@ export const useGetOptionBookmark = (option: {
 
 //찜 하기
 const postBookmark = async (option: postBookmarkPath) => {
-  const { bookId, memberId } = option;
-  const result = await instance.post(`/bookmark/${bookId}/${memberId}`);
+  const { bookId } = option;
+  const result = await instance.post(`/bookmark/${bookId}`);
   return result.data.data;
 };
 
 export const usePostBookmark = (option: postBookmarkPath) => {
-  return useUpdate(postBookmark, option);
+  return useUpdate(postBookmark, option, option);
 };
 
 //찜 삭제
@@ -65,8 +65,8 @@ export const deleteBookMarkItem = async (bookmarkId: string) => {
   return result.data;
 };
 
-export const useDeleteBookmark = (bookmarkId: string) => {
-  return useDelete(deleteBookmark, bookmarkId);
+export const useDeleteBookmark = (option: deleteBookmarkPath) => {
+  return useUpdate(deleteBookMarkItem, option.bookmarkId, option);
 };
 
 // 해당 책에 대한 찜 여부 조회

--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -13,6 +13,7 @@ interface BookDetailCardProps {
   authors: string[];
   bookmarkCount: number;
   isBookmarked: boolean;
+  handleBookmarkClick: () => void;
   publishedDate: string;
   publisher: string;
   averageRating: number;
@@ -30,6 +31,7 @@ function BookDetailCard({
   authors,
   bookmarkCount,
   isBookmarked,
+  handleBookmarkClick,
   publishedDate,
   publisher,
   averageRating,
@@ -44,10 +46,12 @@ function BookDetailCard({
         role="info"
         className="flex w-full max-w-[525px] flex-col items-start justify-start gap-40 mobile:gap-30">
         <BookDetailInfo
+          bookId={bookId}
           bookTitle={bookTitle}
           categories={categories}
           authors={authors}
           isBookmarked={isBookmarked}
+          handleBookmarkClick={handleBookmarkClick}
           bookmarkCount={bookmarkCount}
           publishedDate={publishedDate}
           publisher={publisher}

--- a/src/components/card/bookDetailCard/bookDetailInfo.tsx
+++ b/src/components/card/bookDetailCard/bookDetailInfo.tsx
@@ -9,9 +9,11 @@ import BookAuthor from '@/components/book/bookAuthor/bookAuthor';
 import useFormatDate from '@/hooks/useFormatDate';
 
 interface BookDetailInfoProps {
+  bookId: string;
   bookTitle: string;
   categories: [string, string];
   isBookmarked: boolean;
+  handleBookmarkClick: () => void;
   bookmarkCount: number;
   authors?: string[];
   publisher?: string;
@@ -22,9 +24,11 @@ interface BookDetailInfoProps {
 }
 
 function BookDetailInfo({
+  bookId,
   bookTitle,
   categories,
   isBookmarked,
+  handleBookmarkClick,
   bookmarkCount,
   authors,
   publishedDate,
@@ -34,7 +38,6 @@ function BookDetailInfo({
   price,
 }: BookDetailInfoProps) {
   const customedPublishedDate = useFormatDate(publishedDate);
-  const handleBookmarkClick = () => {};
 
   return (
     <article
@@ -74,7 +77,7 @@ function BookDetailInfo({
         <span className="relative top-12 text-14 text-gray-3">
           ({reviewCount})
         </span>
-        <span className="text-primary text-[24px] font-bold">
+        <span className="text-[24px] font-bold text-primary">
           {averageRating}
         </span>
       </div>

--- a/src/components/orderNavigator/footerOrderNavitgator.tsx
+++ b/src/components/orderNavigator/footerOrderNavitgator.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import OrderBookCount from '@/components/cart/orderBookCount';
 import LikeButton from '@/components/button/likeButton';
 import BookPrice from '@/components/book/bookPrice/bookPrice';
@@ -15,6 +13,7 @@ interface SideOrderNavigatorProps {
   price: number;
   bookId: string;
   isBookmarked: boolean;
+  handleBookmarkClick: () => void;
 }
 
 function FooterOrderNavitgator({
@@ -26,9 +25,8 @@ function FooterOrderNavitgator({
   bookTitle,
   authors,
   isBookmarked,
+  handleBookmarkClick,
 }: SideOrderNavigatorProps) {
-  const [checkBookmarked, setIsBookmarked] = useState(isBookmarked || false);
-
   // 구매하기 버튼 함수
   const { handlePayNowButton } = usePayNowItem({
     bookId: Number(bookId),
@@ -44,9 +42,6 @@ function FooterOrderNavitgator({
     count: orderCount,
   });
 
-  const handleBookmarkClick = () => {
-    setIsBookmarked(!checkBookmarked);
-  };
   return (
     <div
       className="sticky bottom-0 z-10 flex h-70 w-full justify-between
@@ -66,20 +61,20 @@ function FooterOrderNavitgator({
       <div className="flex grow items-center justify-end gap-10">
         <div className="flex-center h-50 w-50 rounded-[5px] border-[1px] border-gray-5 mobile:hidden">
           <LikeButton
-            isLiked={checkBookmarked}
+            isLiked={isBookmarked}
             onClick={handleBookmarkClick}
             width={24}
             height={24}
           />
         </div>
         <button
-          className="flex-center text-primary border-primary h-50 w-135 rounded-[5px] border-2 bg-white
-            text-[17px] font-bold mobile:hidden"
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-primary bg-white text-[17px]
+            font-bold text-primary mobile:hidden"
           onClick={handleAddToBasket}>
           장바구니
         </button>
         <button
-          className="flex-center border-primary bg-primary h-50 w-135 rounded-[5px] border-2 text-[17px]
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-primary bg-primary text-[17px]
             font-bold text-white"
           onClick={handlePayNowButton}>
           구매하기

--- a/src/components/orderNavigator/sideOrderNavigator.tsx
+++ b/src/components/orderNavigator/sideOrderNavigator.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import BookPrice from '@/components/book/bookPrice/bookPrice';
 import LikeButton from '@/components/button/likeButton';
 import OrderBookCount from '@/components/cart/orderBookCount';
@@ -15,6 +13,7 @@ interface SideOrderNavigatorProps {
   setOrderCount: (s: number) => void;
   price: number;
   isBookmarked: boolean;
+  handleBookmarkClick: () => void;
 }
 
 function SideOrderNavigator({
@@ -26,9 +25,8 @@ function SideOrderNavigator({
   setOrderCount,
   price,
   isBookmarked,
+  handleBookmarkClick,
 }: SideOrderNavigatorProps) {
-  const [checkBookmarked, setIsBookmarked] = useState(isBookmarked || false);
-
   // 구매하기 버튼 함수
   const { handlePayNowButton } = usePayNowItem({
     bookId: Number(bookId),
@@ -43,9 +41,7 @@ function SideOrderNavigator({
     bookId: Number(bookId),
     count: orderCount,
   });
-  const handleBookmarkClick = () => {
-    setIsBookmarked(!checkBookmarked);
-  };
+
   return (
     <div
       className="bottom-0 left-0 right-0 z-50 mt-auto flex h-70 w-full flex-col
@@ -67,20 +63,20 @@ function SideOrderNavigator({
       <div className="flex-center grow gap-10">
         <div className="flex-center h-50 w-50 rounded-[5px] border-[1px] border-gray-5">
           <LikeButton
-            isLiked={checkBookmarked}
+            isLiked={isBookmarked}
             onClick={handleBookmarkClick}
             width={24}
             height={24}
           />
         </div>
         <button
-          className="flex-center text-primary border-primary h-50 w-135 rounded-[5px] border-2 bg-white
-            text-[17px] font-bold"
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-primary bg-white text-[17px]
+            font-bold text-primary"
           onClick={handleAddToBasket}>
           장바구니
         </button>
         <button
-          className="flex-center border-primary bg-primary h-50 w-135 rounded-[5px] border-2 text-[17px]
+          className="flex-center h-50 w-135 rounded-[5px] border-2 border-primary bg-primary text-[17px]
             font-bold text-white"
           onClick={handlePayNowButton}>
           구매하기

--- a/src/hooks/useClickLikeButton.ts
+++ b/src/hooks/useClickLikeButton.ts
@@ -1,30 +1,39 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient  } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { useDeleteBookmark, usePostBookmark } from "@/api/bookmark";
 
 function useClickLikeButton({ bookId = "-1", bookmarkId = -1, isBookmarked = false }) {
-  //옵티미스틱 상태
+
+  // 옵티미스틱 상태
   const [bookmarkState, setBookmarkState] = useState(isBookmarked);
   const queryClient = useQueryClient();
-  
+
   // 북마크하는 함수
-  const { mutate: handleCheckBookmarkMutate } = usePostBookmark({
+  const { mutate: handleCheckBookmarkMutate, isPending } = usePostBookmark({
     bookId: Number(bookId),
+    onMutate: () => {
+      queryClient.cancelQueries();
+    },
     onSettle: () => {
-      queryClient.invalidateQueries({ queryKey: ['bookmark', bookId] });
+      queryClient.invalidateQueries({ queryKey: ['bookmark', String(bookId)] });
     },
   });
   
   // 북마크 삭제하는 함수
   const { mutate: handleRemoveBookmarkMutate } = useDeleteBookmark({
     bookmarkId: String(bookmarkId),
+    onMutate: () => {
+      queryClient.cancelQueries();
+    },
     onSettle: () => {
-      queryClient.invalidateQueries({ queryKey: ['bookmark', bookId] });
+      queryClient.invalidateQueries({ queryKey: ['bookmark', String(bookId)] });
     },
   });
 
   const handleBookmarkClick = () => {
+    if (isPending) return;
+
     setBookmarkState(!isBookmarked);
     if (isBookmarked) {
       handleRemoveBookmarkMutate();

--- a/src/hooks/useClickLikeButton.ts
+++ b/src/hooks/useClickLikeButton.ts
@@ -1,0 +1,39 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { useDeleteBookmark, usePostBookmark } from "@/api/bookmark";
+
+function useClickLikeButton({ bookId = "-1", bookmarkId = -1, isBookmarked = false }) {
+  //옵티미스틱 상태
+  const [bookmarkState, setBookmarkState] = useState(isBookmarked);
+  const queryClient = useQueryClient();
+  
+  // 북마크하는 함수
+  const { mutate: handleCheckBookmarkMutate } = usePostBookmark({
+    bookId: Number(bookId),
+    onSettle: () => {
+      queryClient.invalidateQueries({ queryKey: ['bookmark', bookId] });
+    },
+  });
+  
+  // 북마크 삭제하는 함수
+  const { mutate: handleRemoveBookmarkMutate } = useDeleteBookmark({
+    bookmarkId: String(bookmarkId),
+    onSettle: () => {
+      queryClient.invalidateQueries({ queryKey: ['bookmark', bookId] });
+    },
+  });
+
+  const handleBookmarkClick = () => {
+    setBookmarkState(!isBookmarked);
+    if (isBookmarked) {
+      handleRemoveBookmarkMutate();
+    } else {
+      handleCheckBookmarkMutate();
+    }
+  }
+
+  return { bookmarkState, handleBookmarkClick };
+}
+
+export default useClickLikeButton

--- a/src/hooks/usePayNowItem.ts
+++ b/src/hooks/usePayNowItem.ts
@@ -25,7 +25,7 @@ function usePayNowItem({bookId, bookImgUrl, bookTitle, price, authors, count=1}:
       bookTitle: bookTitle,
       price: price,
       authors: authors,
-      clicked: count,
+      count: count,
     },
   ];
 

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -14,6 +14,7 @@ import Spacing from '@/components/container/spacing/spacing';
 import SideOrderNavigator from '@/components/orderNavigator/sideOrderNavigator';
 import FooterOrderNavitgator from '@/components/orderNavigator/footerOrderNavitgator';
 import SkeletonBookDetailCard from '@/components/skeleton/bookDetailCard/skeleton';
+import useClickLikeButton from '@/hooks/useClickLikeButton';
 
 type BookDetailNavLocationType = 'information' | 'review' | 'currency';
 
@@ -39,6 +40,11 @@ export default function BookDetailPage() {
   const { data: bookmarkData } = useGetIsBookmarked({
     bookId: String(bookId),
     enabled: status === 'authenticated',
+  });
+  const { bookmarkState, handleBookmarkClick } = useClickLikeButton({
+    bookId: String(bookId),
+    bookmarkId: bookmarkData?.bookmarkId ?? -1,
+    isBookmarked: bookmarkData?.marked ?? false,
   });
 
   const { mutate: handleViewCountMutate } = usePutBook({
@@ -66,7 +72,8 @@ export default function BookDetailPage() {
             categories={bookData.categories}
             authors={bookData.authors}
             bookmarkCount={bookData.bookmarkCount}
-            isBookmarked={bookmarkData ?? false}
+            isBookmarked={bookmarkState}
+            handleBookmarkClick={handleBookmarkClick}
             publishedDate={bookData.publishedDate}
             publisher={bookData.publisher}
             averageRating={bookData.averageRating}
@@ -105,7 +112,8 @@ export default function BookDetailPage() {
               bookImgUrl={bookData?.bookImgUrl ?? './'}
               bookTitle={bookData?.bookTitle}
               authors={bookData?.authors}
-              isBookmarked={bookmarkData ?? false}
+              isBookmarked={bookmarkState}
+              handleBookmarkClick={handleBookmarkClick}
               price={bookData?.price ?? 0}
               orderCount={orderCount}
               setOrderCount={setOrderCount}
@@ -118,7 +126,8 @@ export default function BookDetailPage() {
           bookImgUrl={bookData?.bookImgUrl ?? './'}
           bookTitle={bookData?.bookTitle}
           authors={bookData?.authors}
-          isBookmarked={bookmarkData ?? false}
+          isBookmarked={bookmarkState}
+          handleBookmarkClick={handleBookmarkClick}
           price={bookData?.price ?? 0}
           orderCount={orderCount}
           setOrderCount={setOrderCount}

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -35,6 +35,7 @@ export default function BookDetailPage() {
   });
   let bookData = data?.data;
 
+  // 로그인 한 상태라면 찜 여부 체크하기
   const { data: bookmarkData } = useGetIsBookmarked({
     bookId: String(bookId),
     enabled: status === 'authenticated',

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -3,6 +3,7 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
 import { useGetBook, usePutBook } from '@/api/book';
+import { useGetIsBookmarked } from '@/api/bookmark';
 import MainLayout from '@/components/layout/mainLayout';
 import BookDetailCard from '@/components/card/bookDetailCard/bookDetailCard';
 import BookDetailNav from '@/components/button/bookDetailNav';
@@ -18,27 +19,35 @@ type BookDetailNavLocationType = 'information' | 'review' | 'currency';
 
 export default function BookDetailPage() {
   const router = useRouter();
+  const { status } = useSession();
   const { bookId } = router.query;
   // 페이지 하단 상품정보, 리뷰, 배송교환환불 탭을 나타내는 state
   const [location, setLocation] =
     useState<BookDetailNavLocationType>('information');
   // 책 구매 수량 state
   const [orderCount, setOrderCount] = useState(1);
+
   const { data, isLoading, isError } = useGetBook({
     endpoint: `${bookId}/detail`,
     params: {
       bookId: String(bookId),
     },
   });
+  let bookData = data?.data;
 
-  // 로그인 한 상태라면 조회수 1 증가
-  const { status } = useSession();
-  const { mutate } = usePutBook({
+  const { data: bookmarkData } = useGetIsBookmarked({
+    bookId: String(bookId),
+    enabled: status === 'authenticated',
+  });
+
+  const { mutate: handleViewCountMutate } = usePutBook({
     bookId: Number(bookId),
   });
+
   useEffect(() => {
     if (status === 'authenticated') {
-      mutate();
+      // 로그인 한 상태라면 조회수 1 증가
+      handleViewCountMutate();
     }
   }, [status]);
 
@@ -50,17 +59,17 @@ export default function BookDetailPage() {
         ) : (
           <BookDetailCard
             bookId={bookId as string}
-            bookImgUrl={data?.data.bookImgUrl}
-            bookTitle={data?.data.bookTitle}
-            price={data?.data.price}
-            categories={data?.data.categories}
-            authors={data?.data.authors}
-            bookmarkCount={data?.data.bookmarkCount}
-            isBookmarked={false}
-            publishedDate={data?.data.publishedDate}
-            publisher={data?.data.publisher}
-            averageRating={data?.data.averageRating}
-            reviewCount={data?.data.reviewCount}
+            bookImgUrl={bookData.bookImgUrl}
+            bookTitle={bookData.bookTitle}
+            price={bookData.price}
+            categories={bookData.categories}
+            authors={bookData.authors}
+            bookmarkCount={bookData.bookmarkCount}
+            isBookmarked={bookmarkData ?? false}
+            publishedDate={bookData.publishedDate}
+            publisher={bookData.publisher}
+            averageRating={bookData.averageRating}
+            reviewCount={bookData.reviewCount}
             orderCount={orderCount}
             setOrderCount={setOrderCount}
           />
@@ -81,9 +90,9 @@ export default function BookDetailPage() {
             {location === 'review' && (
               <Review
                 bookId={bookId as string}
-                ratingDist={data?.data.ratingDist}
-                averageRating={data?.data.averageRating}
-                reviewCount={data?.data.reviewCount}
+                ratingDist={bookData.ratingDist}
+                averageRating={bookData.averageRating}
+                reviewCount={bookData.reviewCount}
               />
             )}
             {location === 'currency' && <RefundTerm />}
@@ -92,11 +101,11 @@ export default function BookDetailPage() {
           <div className="hidden pc:flex pc:pt-50">
             <SideOrderNavigator
               bookId={bookId as string}
-              bookImgUrl={data?.data.bookImgUrl ?? '/.'}
-              bookTitle={data?.data.bookTitle}
-              authors={data?.data.authors}
-              isBookmarked={false}
-              price={data?.data.price ?? 0}
+              bookImgUrl={bookData?.bookImgUrl ?? './'}
+              bookTitle={bookData?.bookTitle}
+              authors={bookData?.authors}
+              isBookmarked={bookmarkData ?? false}
+              price={bookData?.price ?? 0}
               orderCount={orderCount}
               setOrderCount={setOrderCount}
             />
@@ -105,11 +114,11 @@ export default function BookDetailPage() {
 
         <FooterOrderNavitgator
           bookId={bookId as string}
-          bookImgUrl={data?.data.bookImgUrl ?? '/.'}
-          bookTitle={data?.data.bookTitle}
-          authors={data?.data.authors}
-          isBookmarked={false}
-          price={data?.data.price ?? 0}
+          bookImgUrl={bookData?.bookImgUrl ?? './'}
+          bookTitle={bookData?.bookTitle}
+          authors={bookData?.authors}
+          isBookmarked={bookmarkData ?? false}
+          price={bookData?.price ?? 0}
           orderCount={orderCount}
           setOrderCount={setOrderCount}
         />

--- a/src/types/api/bookmark.ts
+++ b/src/types/api/bookmark.ts
@@ -7,7 +7,6 @@ export interface BookmarkParams {
 
 export interface postBookmarkPath {
   bookId: number;
-<<<<<<< HEAD
   onSuccess?: (data:any) => void;
   onSettle?: (data:any) => void;
   onMutate?: (data:any) => void;
@@ -21,6 +20,3 @@ export interface deleteBookmarkPath {
   onMutate?: (data:any) => void;
   onError?: (data:any) => void;
 }
-=======
-}
->>>>>>> 7bc023c41195f6cabf8de92a9ee7cf0be06dfdce

--- a/src/types/api/bookmark.ts
+++ b/src/types/api/bookmark.ts
@@ -7,5 +7,16 @@ export interface BookmarkParams {
 
 export interface postBookmarkPath {
   bookId: number;
-  memberId: number;
+  onSuccess?: (data:any) => void;
+  onSettle?: (data:any) => void;
+  onMutate?: (data:any) => void;
+  onError?: (data:any) => void;
+}
+
+export interface deleteBookmarkPath {
+  bookmarkId: string;
+  onSuccess?: (data:any) => void;
+  onSettle?: (data:any) => void;
+  onMutate?: (data:any) => void;
+  onError?: (data:any) => void;
 }

--- a/src/utils/reactQuery.ts
+++ b/src/utils/reactQuery.ts
@@ -9,7 +9,7 @@ export const useFetch = <T>(
   const context = useQuery({
     queryKey: [queryKey, params],
     queryFn: () => queryFn(params),
-    enabled: enabled ? enabled : true,
+    enabled: enabled ?? true,
   });
 
   return context;

--- a/src/utils/reactQuery.ts
+++ b/src/utils/reactQuery.ts
@@ -4,11 +4,12 @@ export const useFetch = <T>(
   queryKey: string,
   queryFn: (option: T) => Promise<any>,
   params: T,
+  enabled?: boolean,
 ) => {
   const context = useQuery({
     queryKey: [queryKey, params],
     queryFn: () => queryFn(params),
-    enabled: true,
+    enabled: enabled ? enabled : true,
   });
 
   return context;


### PR DESCRIPTION
## 구현사항

음... 상세페이지에 찜 버튼이 3번 들어가서, 쩔수 없이 로직 분리하느라 useClickLikeButton이라는 훅을 만들었습니다. 

최대한 낙관적 업데이트 활용하려 했는데, 하다가 제가 비관적으로 성격 드러워질거 같아서 일단 여기서 스톱합니당...

1. useClickLikeButton 생성
2. useDeleteBokmarkItem api 함수 수정
3. useUpdate 함수가 option으로 onSuceess 받게끔 수정
4. useFetch 함수가 enable 속성도 받게끔 수정


-[] 구현한 내용 및 설명

- [ ] 위에서 찜 버튼을 누르면 아래 찜 버튼도 연동되면서 동시에 잘 클릭되는지 확인해주세요.

## 사용방법

localhost:3000/bookdetail/ 아무번호 로 로그인해서 들어간다음, 찜버튼을 누른다. 

## 스크린샷

위의 찜버튼을 눌러도 아래 footer 찜버튼도 동작함

![Honeycam 2024-02-20 19-16-39](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/603710e4-e685-40c4-bad3-d6a99360b90b)

 fast 3g 환경 기준 버튼 누르면 먼저 하트가 채워지고 그다음 api 받아와서 찜 count 증가

![Honeycam 2024-02-20 19-17-20](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/16c6996f-9ddf-4b20-afc5-22e6f14072a6)


##### close #295
