### PR TITLE
[#303] 아임포트 카카오페이 테스트 결제 연동 

### DIFF
--- a/src/components/button/payment/paymentButton.tsx
+++ b/src/components/button/payment/paymentButton.tsx
@@ -1,0 +1,91 @@
+import useCalculateProductsPrice from '@/hooks/common/useCalculateProductsPrice';
+import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
+import { useRouter } from 'next/router';
+interface PaymentButtonProps {
+  type?: 'mobile' | 'pc';
+}
+function PaymentButton({ type }: PaymentButtonProps) {
+  const router = useRouter();
+  const bookPrice = useCalculateProductsPrice();
+  const delivery = bookPrice > 30000 ? 0 : 3000;
+  const totalPrice = useCalculateTotalPrice({
+    delivery: delivery,
+    discount: 0,
+  });
+  // 결제창 함수
+  function kakaoPay(useremail: string, username: string) {
+    if (typeof window !== 'undefined') {
+      const IMP = window.IMP;
+      const today = new Date();
+      const hours = today.getHours(); // 시
+      const minutes = today.getMinutes(); // 분
+      const seconds = today.getSeconds(); // 초
+      const milliseconds = today.getMilliseconds();
+      const makeMerchantUid =
+        `${hours}` + `${minutes}` + `${seconds}` + `${milliseconds}`;
+
+      IMP.init('imp33057768'); // 가맹점 식별코드
+      IMP.request_pay(
+        {
+          pg: 'kakaopay.TC0ONETIME', // PG사 코드표에서 선택
+          pay_method: 'card', // 결제 방식
+          merchant_uid: 'IMP' + makeMerchantUid, // 결제 고유 번호
+          name: '리드미', // 제품명
+          amount: totalPrice, // 가격
+          buyer_email: useremail,
+          buyer_name: username,
+        },
+        async function (rsp) {
+          if (rsp.success) {
+            //결제 성공시
+            console.log(rsp + '결제성공');
+            router.push('/paymented');
+            //결제 성공시 프로젝트 DB저장 요청
+
+            if (rsp.status === 200) {
+              // DB저장 성공시
+              alert('결제 완료!');
+              window.location.reload();
+            } else {
+              // 결제완료 후 DB저장 실패시
+              alert(
+                `error:[${rsp.status}]\n결제요청이 승인된 경우 관리자에게 문의바랍니다.`,
+              );
+              // DB저장 실패시 status에 따라 추가적인 작업 가능성
+            }
+          } else if (rsp.success === false) {
+            // 결제 실패시
+            alert(rsp.error_msg);
+          }
+        },
+      );
+    }
+  }
+
+  // 결제 함수 호출
+  function handlePaymentButtonClick() {
+    const user_email = 'ayjislove@gmail.com';
+    const username = '안윤진';
+    kakaoPay(user_email, username);
+  }
+  if (type == 'mobile')
+    return (
+      <button
+        className="flex-center sticky bottom-0 z-[100] h-70 border-t border-gray-1 bg-white pc:hidden"
+        onClick={handlePaymentButtonClick}>
+        <div className="flex-center mx-40 h-50 w-full bg-primary text-white">
+          {' '}
+          {totalPrice}원 결제하기
+        </div>
+      </button>
+    );
+  return (
+    <button
+      className="flex-center h-70 w-full border-t border-gray-1 bg-primary  text-white mobile:hidden tablet:hidden"
+      onClick={handlePaymentButtonClick}>
+      {totalPrice}원 결제하기
+    </button>
+  );
+}
+
+export default PaymentButton;

--- a/src/components/button/payment/paymentButton.tsx
+++ b/src/components/button/payment/paymentButton.tsx
@@ -74,8 +74,7 @@ function PaymentButton({ type }: PaymentButtonProps) {
         className="flex-center sticky bottom-0 z-[100] h-70 border-t border-gray-1 bg-white pc:hidden"
         onClick={handlePaymentButtonClick}>
         <div className="flex-center mx-40 h-50 w-full bg-primary text-white">
-          {' '}
-          {totalPrice}원 결제하기
+          {totalPrice.toLocaleString()}원 결제하기
         </div>
       </button>
     );
@@ -83,7 +82,7 @@ function PaymentButton({ type }: PaymentButtonProps) {
     <button
       className="flex-center h-70 w-full border-t border-gray-1 bg-primary  text-white mobile:hidden tablet:hidden"
       onClick={handlePaymentButtonClick}>
-      {totalPrice}원 결제하기
+      {totalPrice.toLocaleString()}원 결제하기
     </button>
   );
 }

--- a/src/components/button/payment/paymentButton.tsx
+++ b/src/components/button/payment/paymentButton.tsx
@@ -1,3 +1,4 @@
+import { useGetMember } from '@/api/member';
 import useCalculateProductsPrice from '@/hooks/common/useCalculateProductsPrice';
 import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
 import { useRouter } from 'next/router';
@@ -34,6 +35,11 @@ function PaymentButton({ type }: PaymentButtonProps) {
           amount: totalPrice, // 가격
           buyer_email: useremail,
           buyer_name: username,
+          m_redirect_url:
+            window.location.protocol +
+            '//' +
+            window.location.host +
+            '/paymented', //TODO: 모바일 결제 시 이동페이지, 추후 수정
         },
         async function (rsp) {
           if (rsp.success) {
@@ -41,18 +47,6 @@ function PaymentButton({ type }: PaymentButtonProps) {
             console.log(rsp + '결제성공');
             router.push('/paymented');
             //결제 성공시 프로젝트 DB저장 요청
-
-            if (rsp.status === 200) {
-              // DB저장 성공시
-              alert('결제 완료!');
-              window.location.reload();
-            } else {
-              // 결제완료 후 DB저장 실패시
-              alert(
-                `error:[${rsp.status}]\n결제요청이 승인된 경우 관리자에게 문의바랍니다.`,
-              );
-              // DB저장 실패시 status에 따라 추가적인 작업 가능성
-            }
           } else if (rsp.success === false) {
             // 결제 실패시
             alert(rsp.error_msg);
@@ -61,10 +55,10 @@ function PaymentButton({ type }: PaymentButtonProps) {
       );
     }
   }
-
+  const { data } = useGetMember();
   // 결제 함수 호출
   function handlePaymentButtonClick() {
-    const user_email = 'ayjislove@gmail.com';
+    const user_email = data.email;
     const username = '안윤진';
     kakaoPay(user_email, username);
   }

--- a/src/components/button/payment/paymentButton.tsx
+++ b/src/components/button/payment/paymentButton.tsx
@@ -5,6 +5,10 @@ import { useRouter } from 'next/router';
 interface PaymentButtonProps {
   type?: 'mobile' | 'pc';
 }
+
+interface response {
+  success: boolean;
+}
 function PaymentButton({ type }: PaymentButtonProps) {
   const router = useRouter();
   const bookPrice = useCalculateProductsPrice();
@@ -41,15 +45,15 @@ function PaymentButton({ type }: PaymentButtonProps) {
             window.location.host +
             '/paymented', //TODO: 모바일 결제 시 이동페이지, 추후 수정
         },
-        async function (rsp) {
+        async function (rsp: response) {
           if (rsp.success) {
             //결제 성공시
             console.log(rsp + '결제성공');
             router.push('/paymented');
             //결제 성공시 프로젝트 DB저장 요청
-          } else if (rsp.success === false) {
+          } else {
             // 결제 실패시
-            alert(rsp.error_msg);
+            alert('결제에 실패했습니다.');
           }
         },
       );

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -5,7 +5,7 @@ import { REQUIRED_FOR_PAYMENT } from 'src/constants/sign';
 import Link from 'next/link';
 import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
 import useCalculateProductsPrice from '@/hooks/common/useCalculateProductsPrice';
-
+import PaymentButton from '@/components/button/payment/paymentButton';
 interface TotalPriceCardProps {
   checkbox?: boolean;
   button?: boolean;
@@ -48,11 +48,8 @@ function TotalPriceCard({
           showLastButton={false}
         />
       )}
-      {button && (
-        <Link className="mobile:hidden tablet:hidden" href="/paymented">
-          <RegisterButton>{totalPrice.toString()}원 결제하기</RegisterButton>
-        </Link>
-      )}
+
+      {button && <PaymentButton />}
     </div>
   );
 }

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -1,8 +1,6 @@
 import TermsCheckbox from '@/components/container/terms/terms';
 import TotalPrice from '@/components/card/totalPaymentCard/totalPrice';
-import RegisterButton from '@/components/button/register/registerButton';
 import { REQUIRED_FOR_PAYMENT } from 'src/constants/sign';
-import Link from 'next/link';
 import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
 import useCalculateProductsPrice from '@/hooks/common/useCalculateProductsPrice';
 import PaymentButton from '@/components/button/payment/paymentButton';
@@ -30,12 +28,12 @@ function TotalPriceCard({
 
   return (
     <div className="flex w-full flex-col gap-20 rounded-[10px] border border-gray-1 p-30 mobile:p-20 pc:sticky pc:top-280">
-      <TotalPrice title="총 상품 금액" price={bookPrice.toString()} />
-      <TotalPrice title="총 배송비" price={delivery.toString()} />
-      <TotalPrice title="총 할인 금액" price={discount.toString()} />
+      <TotalPrice title="총 상품 금액" price={bookPrice.toLocaleString()} />
+      <TotalPrice title="총 배송비" price={delivery.toLocaleString()} />
+      <TotalPrice title="총 할인 금액" price={discount.toLocaleString()} />
       <TotalPrice
         title="결제 금액"
-        price={totalPrice.toString()}
+        price={totalPrice.toLocaleString()}
         font="font-bold"
         text="text-20"
         color={color}

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -11,8 +11,7 @@ interface TotalPriceCardProps {
   delivery?: number;
   discount?: number;
 }
-// tablet:w-688 mobile:w-330
-//TODO : TotalPrice컴포넌트의 price props, RegisterButton 가격 TotalPriceCardProps로 받아야함
+
 function TotalPriceCard({
   checkbox = true,
   button = true,
@@ -28,12 +27,18 @@ function TotalPriceCard({
 
   return (
     <div className="flex w-full flex-col gap-20 rounded-[10px] border border-gray-1 p-30 mobile:p-20 pc:sticky pc:top-280">
-      <TotalPrice title="총 상품 금액" price={bookPrice.toLocaleString()} />
-      <TotalPrice title="총 배송비" price={delivery.toLocaleString()} />
-      <TotalPrice title="총 할인 금액" price={discount.toLocaleString()} />
+      <TotalPrice
+        title="총 상품 금액"
+        price={`${bookPrice.toLocaleString()}원`}
+      />
+      <TotalPrice title="총 배송비" price={`${delivery.toLocaleString()}원`} />
+      <TotalPrice
+        title="총 할인 금액"
+        price={`${discount.toLocaleString()}원`}
+      />
       <TotalPrice
         title="결제 금액"
-        price={totalPrice.toLocaleString()}
+        price={`${totalPrice.toLocaleString()}원`}
         font="font-bold"
         text="text-20"
         color={color}

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -6,6 +6,7 @@ import { useAtom } from 'jotai';
 import { pointVisibleAtom } from '@/store/state'; // basketItemList 추가
 import { useSession } from 'next-auth/react';
 import useGetBasKetQuery from '@/hooks/useGetBasKetQuery';
+import Script from 'next/script';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -23,6 +24,8 @@ function MainLayout({ children }: MainLayoutProps) {
 
   return (
     <>
+      <Script async src="https://code.jquery.com/jquery-1.12.4.min.js" />
+      <Script async src="https://cdn.iamport.kr/js/iamport.payment-1.2.0.js" />
       <Header
         isLoggedIn={status === 'authenticated'}
         numItemsOfCart={data?.length} // basketItems의 길이로 업데이트

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,13 +6,12 @@ import {
 } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
-import { type ReactElement, type ReactNode, useEffect } from 'react';
+import { type ReactElement, type ReactNode } from 'react';
 import type { NextPage } from 'next';
 import Toast from '@/components/toast/toast';
 import 'react-toastify/dist/ReactToastify.css';
 import InitialContainer from '@/components/container/initialContainer/initialContainer';
 import { SessionProvider } from 'next-auth/react';
-import Script from 'next/script';
 
 const queryClient = new QueryClient();
 
@@ -33,9 +32,6 @@ export default function App({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Script async src="https://cdn.iamport.kr/v1/iamport.js" />
-      <Script async src="https://code.jquery.com/jquery-1.12.4.min.js" />
-      <Script async src="https://cdn.iamport.kr/js/iamport.payment-1.2.0.js" />
       <SessionProvider session={session}>
         <InitialContainer />
         <HydrationBoundary state={pageProps.dehydratedState}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import Toast from '@/components/toast/toast';
 import 'react-toastify/dist/ReactToastify.css';
 import InitialContainer from '@/components/container/initialContainer/initialContainer';
 import { SessionProvider } from 'next-auth/react';
+import Script from 'next/script';
 
 const queryClient = new QueryClient();
 
@@ -32,6 +33,9 @@ export default function App({
 
   return (
     <QueryClientProvider client={queryClient}>
+      <Script async src="https://cdn.iamport.kr/v1/iamport.js" />
+      <Script async src="https://code.jquery.com/jquery-1.12.4.min.js" />
+      <Script async src="https://cdn.iamport.kr/js/iamport.payment-1.2.0.js" />
       <SessionProvider session={session}>
         <InitialContainer />
         <HydrationBoundary state={pageProps.dehydratedState}>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,12 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="ko">
-      <Head>
-        <meta
-          http-equiv="Content-Security-Policy"
-          content="upgrade-insecure-requests"
-        />
-      </Head>
+      <Head></Head>
       <body>
         <Main />
         <div id="portal" />

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -4,7 +4,6 @@ import BookPaymentCardList from '@/components/card/bookPaymentCard/bookPaymentCa
 import { ReactElement } from 'react';
 import MainLayout from '@/components/layout/mainLayout';
 import TotalPriceCard from '@/components/card/totalPaymentCard';
-import Link from 'next/link';
 import { basketItemList } from '@/store/state';
 import { useAtomValue } from 'jotai';
 import PaymentButton from '@/components/button/payment/paymentButton';

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -7,6 +7,7 @@ import TotalPriceCard from '@/components/card/totalPaymentCard';
 import Link from 'next/link';
 import { basketItemList } from '@/store/state';
 import { useAtomValue } from 'jotai';
+import PaymentButton from '@/components/button/payment/paymentButton';
 
 export default function Order() {
   const items = useAtomValue(basketItemList);
@@ -24,13 +25,8 @@ export default function Order() {
         <div className="sticky top-177 mx-40 mb-180 mobile:mt-80 tablet:mt-80">
           <TotalPriceCard />
         </div>
-        <Link
-          className="flex-center sticky bottom-0 h-70 w-full border-t border-gray-1 bg-white pc:hidden"
-          href="/paymented">
-          <div className="mx-40 flex w-full">
-            <RegisterButton>결제하기</RegisterButton>
-          </div>
-        </Link>
+
+        <PaymentButton type="mobile" />
       </div>
     </div>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -59,7 +59,7 @@ body {
     color: --gray-3;
   }
   input {
-    accent-color: var(--primary);
+    accent-color: navy;
   }
   .flex-center {
     @apply flex items-center justify-center;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,8 @@
+index.d.ts;
+export {};
+
+declare global {
+  interface Window {
+    IMP: any;
+  }
+}


### PR DESCRIPTION
## 구현사항
처음 해보니 헷갈리는 부분이 많아 오래 걸렸습니다ㅠㅠ 
- [x] 아임포트 카카오페이 테스트 결제 연동 

## 사용방법
특이하게도 카카오페이의 보안 정책 상 크롬 개발자 모드를 킨 상태로 확인을 못하게 막아두었다 하더라고요. 개발자도구를 키지 않은 상태로 테스트 해주세요.
테스트 결제이므로 실제로 현금이 빠져나가지 않습니다! 안심하세용 

- feat/kakaopay 브랜치에서 order 페이지
-  결제하기 버튼을 누르기 -> 휴대폰으로 qr 찍기 -> 결제 완료 페이지로 route, 휴대폰으로 결제 내역 전송됨

## 스크린샷
<img width="671" alt="스크린샷 2024-02-21 오후 9 57 57" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/6267fc3a-dce1-409d-9683-36562eac0342">

![결제후](https://github.com/bookstore-README/front_bookstore-README/assets/119280160/9ad1a61c-ea03-4ce2-a3d7-b15afb8110c7)


##TODO
[] 배송 api 연결해서 구매목록 post
[] 상품명 변경: 현재는 리드미라고 뜰 텐데 order 목록을 참고해 00외 1권 구매 와 같이 띄울 수 있도록 훅을 구현할 생각입니다.
[] kg 이니시스로 pg사 변경

##### close #303
##### close #304
##### close #229