### PR TITLE
[#254] 결제상세 페이지 UI

### DIFF
--- a/src/components/card/bookOrderCard/bookOrderCardList.tsx
+++ b/src/components/card/bookOrderCard/bookOrderCardList.tsx
@@ -13,7 +13,7 @@ export interface BookOrderCardListProps {
 }
 
 function BookOrderCardList({ orderData }: BookOrderCardListProps) {
-  if (!orderData) return;
+  if (!orderData) return null;
 
   return (
     <div className="flex max-w-[1080px] flex-col">

--- a/src/components/container/orderCompletedSection/index.tsx
+++ b/src/components/container/orderCompletedSection/index.tsx
@@ -15,15 +15,22 @@ const DcontentData = [
 const PcontentData = ['신용카드', '22,500원'];
 const orderDate = '2024.02.05';
 
-function OrderCompletedSection() {
+function OrderCompletedSection({
+  paymentDetail = true,
+}: {
+  paymentDetail?: boolean;
+}) {
   return (
     <div className="flex w-[1084px] flex-col gap-60 mobile:w-330 tablet:w-[688px] ">
-      <InfoCard
-        title="결제가 완료되었습니다!"
-        content={`주문일자 ${orderDate}`}
-      />
+      {paymentDetail && (
+        <InfoCard
+          title="결제가 완료되었습니다!"
+          content={`주문일자 ${orderDate}`}
+        />
+      )}
       <div className="flex gap-34">
-        <div className="flex w-[618px] flex-col gap-60 mobile:w-full tablet:w-full">
+        <div
+          className={`flex w-[618px] flex-col gap-60 mobile:w-full tablet:w-full ${paymentDetail ? 'mt-0' : 'mt-45'}`}>
           <TitleContentCard
             title="배송지 정보"
             titleData={DELIVERY_INFO}

--- a/src/components/container/orderDate/orderCount.tsx
+++ b/src/components/container/orderDate/orderCount.tsx
@@ -21,7 +21,7 @@ function OrderCount({ orderId, orderDate, orderCount }: OrderCountProps) {
           <div className="ml-23 mr-18 h-12 w-1 bg-gray-1"></div>
           <span className="text-14 text-gray-3">주문 {orderCount}건</span>
         </div>
-        <Link className="flex" href={`order/${orderId}`}>
+        <Link className="flex" href={`/mypage/order/${orderId}`}>
           <span className="text-15">주문상세</span>
           <Image
             src="/icons/RightArrow.svg"

--- a/src/pages/mypage/order/[orderId].tsx
+++ b/src/pages/mypage/order/[orderId].tsx
@@ -1,0 +1,13 @@
+import OrderCompletedSection from '@/components/container/orderCompletedSection';
+import MainLayout from '@/components/layout/mainLayout';
+import { ReactElement } from 'react';
+
+function MyPageOrderDetail() {
+  return <OrderCompletedSection paymentDetail={false} />;
+}
+
+export default MyPageOrderDetail;
+
+MyPageOrderDetail.getLayout = function getLayout(page: ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
+};


### PR DESCRIPTION
## 구현사항
- [x] 'mypage/order' 에서 주문 상세 클릭시(OrderCount 컴포넌트에 있음) 주문 상세 페이지로 이동하는데 
   기존 'order/${orderId}' -> `/mypage/order/${orderId}` (아래와같이) 수정함
```
  <Link className="flex" href={`/mypage/order/${orderId}`}>
    <span className="text-15">주문상세</span>
    <Image
      src="/icons/RightArrow.svg"
      alt="화살표버튼"
      width={20}
      height={20}
    />
  </Link>
```

- [x] 제품상세 페이지는 paymented(결제완료 페이지) container컴포넌트 그대로 사용

## 사용방법
- 결제완료랑 주문상세가 같아서 아래처럼 사용함
```
<OrderCompletedSection paymentDetail={false} />; 
```
- paymentDetail= true
<img width="866" alt="스크린샷 2024-02-22 오전 5 54 33" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/a0bb1aa2-7b1b-4ae5-83c4-c1d2bc8531d9">

- paymentDetail=false
<img width="867" alt="스크린샷 2024-02-22 오전 5 54 10" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/4fbebd8b-1ecd-4e3e-8775-c3f7b30751b7">


## 스크린샷

https://github.com/bookstore-README/front_bookstore-README/assets/138510303/3799c9a3-6e8a-4da5-ba96-6db7d0dfa633



##### close #254
