### PR TITLE
[#355] 비로그인 상태의 헤더가 장바구니 아이템을 get 하는 문제해결

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -7,6 +7,7 @@ import BookmarkButton from '@/components/button/header/bookmarkButton';
 import HeaderLayout from '@/components/layout/headerLayout';
 import SignUpButton from '@/components/button/signUpButton';
 import ReadMeButton from '../button/header/readmeButton';
+import useGetBasKetQuery from '@/hooks/useGetBasKetQuery';
 
 export interface HeaderProps {
   isLoggedIn: boolean;
@@ -36,11 +37,9 @@ function NonLoggedInHeader() {
 }
 
 // 로그인한 상태의 헤더
-function LoggedInHeader({
-  numItemsOfCart,
-}: {
-  numItemsOfCart: number | undefined;
-}) {
+function LoggedInHeader() {
+  // authenticated 상태인 경우에만 useGetBasKetQuery() 호출
+  const { data } = useGetBasKetQuery();
   return (
     <div
       className="relative z-10 mx-15 flex h-50 min-w-fit max-w-full items-center
@@ -51,7 +50,7 @@ function LoggedInHeader({
         <SignOutButton />
         <Separator />
         <BookmarkButton />
-        <CartButton numItemsOfCart={numItemsOfCart} />
+        <CartButton numItemsOfCart={data?.length} />
         <MyPageButton />
       </div>
     </div>
@@ -59,10 +58,10 @@ function LoggedInHeader({
 }
 
 // 헤더 컴포넌트
-function Header({ isLoggedIn, numItemsOfCart }: HeaderProps) {
+function Header({ isLoggedIn }: HeaderProps) {
   return isLoggedIn ? (
     <HeaderLayout isLoggedIn={isLoggedIn}>
-      <LoggedInHeader numItemsOfCart={numItemsOfCart} />
+      <LoggedInHeader />
     </HeaderLayout>
   ) : (
     <HeaderLayout isLoggedIn={isLoggedIn}>

--- a/src/components/layout/mainLayout.tsx
+++ b/src/components/layout/mainLayout.tsx
@@ -16,7 +16,6 @@ function MainLayout({ children }: MainLayoutProps) {
   const [ref, isIntersecting] = useInfinite();
   const [, setPointVisible] = useAtom(pointVisibleAtom);
   const { status } = useSession();
-  const { data } = useGetBasKetQuery();
 
   useEffect(() => {
     setPointVisible(isIntersecting);
@@ -28,7 +27,6 @@ function MainLayout({ children }: MainLayoutProps) {
       <Script async src="https://cdn.iamport.kr/js/iamport.payment-1.2.0.js" />
       <Header
         isLoggedIn={status === 'authenticated'}
-        numItemsOfCart={data?.length} // basketItems의 길이로 업데이트
       />
       <div className="relative grid auto-rows-auto place-items-center">
         <div className="h-20 w-300" ref={ref} />


### PR DESCRIPTION
## 구현사항
동작에는 문제가 없어서 몰랐는데 개발자 도구를 열었다가 끊임없이 발생하는 403에러에 당황하여 문제가 있구나.. 알게 되었습니다..
#355 와 같은 이유로 mainlayout을 사용하는 모든 페이지에서 403에러가 발생했습니다.
그래서 기존처럼 mainlayout에서 get해서 헤더로 전달하는 대신 loggedinheader 내부에서 장바구니 데이터를 get 하도록 변경하였습니다. 

## 변경전
<img width="1182" alt="스크린샷 2024-02-22 오후 5 10 25" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/a8d4ff66-2001-412b-93eb-970c93a86426">

## 사용방법
비로그인 상태에서 403에러가 발생하지 않는지, 로그인 상태에선 헤더가 장바구니 데이터 개수를 잘 받아오는지 확인 부탁드려요.

##### close #355
