### PR TITLE
[#350] 결제페이지 필수동의사항 체크되어야 진행되도록 수정 

### DIFF
--- a/src/components/button/payment/paymentButton.tsx
+++ b/src/components/button/payment/paymentButton.tsx
@@ -4,12 +4,15 @@ import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
 import { useRouter } from 'next/router';
 interface PaymentButtonProps {
   type?: 'mobile' | 'pc';
+  disabled?: boolean;
 }
 
 interface response {
   success: boolean;
 }
-function PaymentButton({ type }: PaymentButtonProps) {
+function PaymentButton({ type, disabled }: PaymentButtonProps) {
+  console.log('type : ' + type);
+  console.log('diabled : ' + disabled);
   const router = useRouter();
   const bookPrice = useCalculateProductsPrice();
   const delivery = bookPrice > 30000 ? 0 : 3000;
@@ -19,6 +22,8 @@ function PaymentButton({ type }: PaymentButtonProps) {
   });
   // 결제창 함수
   function kakaoPay(useremail: string, username: string) {
+    console.log('type : ' + type);
+    console.log('diabled : ' + disabled);
     if (typeof window !== 'undefined') {
       const IMP = window.IMP;
       const today = new Date();
@@ -62,26 +67,36 @@ function PaymentButton({ type }: PaymentButtonProps) {
   const { data } = useGetMember();
   // 결제 함수 호출
   function handlePaymentButtonClick() {
-    const user_email = data.email;
-    const username = '안윤진';
-    kakaoPay(user_email, username);
+    console.log('type : ' + type);
+    console.log('diabled : ' + disabled);
+    console.log('클릭');
+    // const user_email = data.email;
+    // const username = '안윤진';
+    // kakaoPay(user_email, username);
   }
-  if (type == 'mobile')
-    return (
+  // console.log(disabled);
+
+  return (
+    <>
       <button
-        className="flex-center sticky bottom-0 z-[100] h-70 border-t border-gray-1 bg-white pc:hidden"
+        className="flex-center fixed bottom-0 left-0 z-[100] h-70 w-full bg-white pc:hidden"
+        disabled={disabled}
+        type="submit"
         onClick={handlePaymentButtonClick}>
         <div className="flex-center mx-40 h-50 w-full bg-primary text-white">
-          {totalPrice.toLocaleString()}원 결제하기
+          {totalPrice.toLocaleString()}원 결제하기 {disabled ? 'true' : 'false'}
+          {type}
         </div>
       </button>
-    );
-  return (
-    <button
-      className="flex-center h-70 w-full border-t border-gray-1 bg-primary  text-white mobile:hidden tablet:hidden"
-      onClick={handlePaymentButtonClick}>
-      {totalPrice.toLocaleString()}원 결제하기
-    </button>
+      <button
+        className="flex-center h-70 w-full border-t border-gray-1 bg-primary  text-white mobile:hidden tablet:hidden"
+        type="submit"
+        onClick={handlePaymentButtonClick}
+        disabled={disabled}>
+        {totalPrice.toLocaleString()}원 결제하기 {disabled ? 'true' : 'false'}
+        {type}
+      </button>
+    </>
   );
 }
 

--- a/src/components/button/payment/paymentButton.tsx
+++ b/src/components/button/payment/paymentButton.tsx
@@ -1,18 +1,16 @@
 import { useGetMember } from '@/api/member';
+import { notify } from '@/components/toast/toast';
 import useCalculateProductsPrice from '@/hooks/common/useCalculateProductsPrice';
 import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
 import { useRouter } from 'next/router';
 interface PaymentButtonProps {
-  type?: 'mobile' | 'pc';
-  disabled?: boolean;
+  isAllChecked?: boolean;
 }
 
 interface response {
   success: boolean;
 }
-function PaymentButton({ type, disabled }: PaymentButtonProps) {
-  console.log('type : ' + type);
-  console.log('diabled : ' + disabled);
+function PaymentButton({ isAllChecked }: PaymentButtonProps) {
   const router = useRouter();
   const bookPrice = useCalculateProductsPrice();
   const delivery = bookPrice > 30000 ? 0 : 3000;
@@ -22,8 +20,6 @@ function PaymentButton({ type, disabled }: PaymentButtonProps) {
   });
   // 결제창 함수
   function kakaoPay(useremail: string, username: string) {
-    console.log('type : ' + type);
-    console.log('diabled : ' + disabled);
     if (typeof window !== 'undefined') {
       const IMP = window.IMP;
       const today = new Date();
@@ -67,34 +63,36 @@ function PaymentButton({ type, disabled }: PaymentButtonProps) {
   const { data } = useGetMember();
   // 결제 함수 호출
   function handlePaymentButtonClick() {
-    console.log('type : ' + type);
-    console.log('diabled : ' + disabled);
-    console.log('클릭');
-    // const user_email = data.email;
-    // const username = '안윤진';
-    // kakaoPay(user_email, username);
+    if (isAllChecked) {
+      const user_email = data.email;
+      const username = '안윤진';
+      kakaoPay(user_email, username);
+    } else {
+      notify({
+        type: 'error',
+        text: '모든약관에 동의하셔야 합니다. ✅',
+      });
+    }
   }
-  // console.log(disabled);
 
   return (
     <>
+      <div className="borer-primary border-t-1 fixed bottom-0 left-0 z-[100] w-full border bg-white px-40 py-10 pc:hidden">
+        <button
+          className="flex-center h-50 w-full rounded border bg-white "
+          type="submit"
+          onClick={handlePaymentButtonClick}>
+          <div className="flex-center  h-50 w-full bg-primary text-white">
+            {totalPrice.toLocaleString()}원 결제하기
+          </div>
+        </button>
+      </div>
+
       <button
-        className="flex-center fixed bottom-0 left-0 z-[100] h-70 w-full bg-white pc:hidden"
-        disabled={disabled}
+        className="flex-center mt-20 h-50 w-full rounded border-t  border-gray-1 bg-primary text-white mobile:hidden tablet:hidden"
         type="submit"
         onClick={handlePaymentButtonClick}>
-        <div className="flex-center mx-40 h-50 w-full bg-primary text-white">
-          {totalPrice.toLocaleString()}원 결제하기 {disabled ? 'true' : 'false'}
-          {type}
-        </div>
-      </button>
-      <button
-        className="flex-center h-70 w-full border-t border-gray-1 bg-primary  text-white mobile:hidden tablet:hidden"
-        type="submit"
-        onClick={handlePaymentButtonClick}
-        disabled={disabled}>
-        {totalPrice.toLocaleString()}원 결제하기 {disabled ? 'true' : 'false'}
-        {type}
+        {totalPrice.toLocaleString()}원 결제하기
       </button>
     </>
   );

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -4,12 +4,18 @@ import { REQUIRED_FOR_PAYMENT } from 'src/constants/sign';
 import useCalculateTotalPrice from '@/hooks/common/useCalculateTotalPrice';
 import useCalculateProductsPrice from '@/hooks/common/useCalculateProductsPrice';
 import PaymentButton from '@/components/button/payment/paymentButton';
+import { useForm, FormProvider } from 'react-hook-form';
+import { useEffect, useState } from 'react';
+
 interface TotalPriceCardProps {
   checkbox?: boolean;
   button?: boolean;
   color?: string;
   delivery?: number;
   discount?: number;
+}
+interface FormDataType {
+  selectAll: boolean;
 }
 
 function TotalPriceCard({
@@ -24,36 +30,71 @@ function TotalPriceCard({
     delivery: delivery,
     discount: discount,
   });
+  const method = useForm({
+    mode: 'onBlur',
+    defaultValues: {
+      selectAll: false,
+    },
+  });
+  const { handleSubmit } = method;
+  const [isAllChecked, setIsAllChecked] = useState(false);
+  const onSubmit = (selectAll: FormDataType) => {
+    // console.log(selectAll);
+    // if (isAllChecked)
+    //   const checkValidataion = {
+    //     selectAll: data.selectAll,
+    //   };
+    // if (!checkValidataion.selectAll) {
+    //   alert('약관동의를해주세요');
+    // }
+  };
 
+  // console.log(isAllChecked);
+  const handleCheckedChange = (checkedStates: any) => {
+    setIsAllChecked(checkedStates);
+    console.log(checkedStates);
+  };
+
+  useEffect(() => {
+    if (isAllChecked) setIsAllChecked(isAllChecked);
+    console.log(isAllChecked);
+  }, [isAllChecked]);
   return (
-    <div className="flex w-full flex-col gap-20 rounded-[10px] border border-gray-1 p-30 mobile:p-20 pc:sticky pc:top-280">
-      <TotalPrice
-        title="총 상품 금액"
-        price={`${bookPrice.toLocaleString()}원`}
-      />
-      <TotalPrice title="총 배송비" price={`${delivery.toLocaleString()}원`} />
-      <TotalPrice
-        title="총 할인 금액"
-        price={`${discount.toLocaleString()}원`}
-      />
-      <TotalPrice
-        title="결제 금액"
-        price={`${totalPrice.toLocaleString()}원`}
-        font="font-bold"
-        text="text-20"
-        color={color}
-      />
-      {checkbox && (
-        <TermsCheckbox
-          entire="전체동의(필수)"
-          checkContent={REQUIRED_FOR_PAYMENT}
-          useFormContextProps={false}
-          showLastButton={false}
+    <FormProvider {...method}>
+      <div className="flex w-full flex-col gap-20 rounded-[10px] border border-gray-1 p-30 mobile:static mobile:p-20 tablet:static pc:sticky pc:top-280">
+        <TotalPrice
+          title="총 상품 금액"
+          price={`${bookPrice.toLocaleString()}원`}
         />
-      )}
-
-      {button && <PaymentButton />}
-    </div>
+        <TotalPrice
+          title="총 배송비"
+          price={`${delivery.toLocaleString()}원`}
+        />
+        <TotalPrice
+          title="총 할인 금액"
+          price={`${discount.toLocaleString()}원`}
+        />
+        <TotalPrice
+          title="결제 금액"
+          price={`${totalPrice.toLocaleString()}원`}
+          font="font-bold"
+          text="text-20"
+          color={color}
+        />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {checkbox && (
+            <TermsCheckbox
+              entire="전체동의(필수)"
+              checkContent={REQUIRED_FOR_PAYMENT}
+              useFormContextProps={false}
+              showLastButton={false}
+              onCheckedChange={handleCheckedChange}
+            />
+          )}
+          {button && <PaymentButton disabled={!isAllChecked} />}
+        </form>
+      </div>
+    </FormProvider>
   );
 }
 

--- a/src/components/card/totalPaymentCard/index.tsx
+++ b/src/components/card/totalPaymentCard/index.tsx
@@ -30,71 +30,42 @@ function TotalPriceCard({
     delivery: delivery,
     discount: discount,
   });
-  const method = useForm({
-    mode: 'onBlur',
-    defaultValues: {
-      selectAll: false,
-    },
-  });
-  const { handleSubmit } = method;
   const [isAllChecked, setIsAllChecked] = useState(false);
-  const onSubmit = (selectAll: FormDataType) => {
-    // console.log(selectAll);
-    // if (isAllChecked)
-    //   const checkValidataion = {
-    //     selectAll: data.selectAll,
-    //   };
-    // if (!checkValidataion.selectAll) {
-    //   alert('약관동의를해주세요');
-    // }
-  };
 
-  // console.log(isAllChecked);
-  const handleCheckedChange = (checkedStates: any) => {
+  // 약관동이 체크가 변할때마다 감지하여 isAllChecked를 변경
+  const handleCheckedChange = (checkedStates: boolean) => {
     setIsAllChecked(checkedStates);
-    console.log(checkedStates);
   };
 
-  useEffect(() => {
-    if (isAllChecked) setIsAllChecked(isAllChecked);
-    console.log(isAllChecked);
-  }, [isAllChecked]);
   return (
-    <FormProvider {...method}>
-      <div className="flex w-full flex-col gap-20 rounded-[10px] border border-gray-1 p-30 mobile:static mobile:p-20 tablet:static pc:sticky pc:top-280">
-        <TotalPrice
-          title="총 상품 금액"
-          price={`${bookPrice.toLocaleString()}원`}
+    <div className="flex w-full flex-col gap-20 rounded-[10px] border border-gray-1 p-30 mobile:static mobile:p-20 tablet:static pc:sticky pc:top-280">
+      <TotalPrice
+        title="총 상품 금액"
+        price={`${bookPrice.toLocaleString()}원`}
+      />
+      <TotalPrice title="총 배송비" price={`${delivery.toLocaleString()}원`} />
+      <TotalPrice
+        title="총 할인 금액"
+        price={`${discount.toLocaleString()}원`}
+      />
+      <TotalPrice
+        title="결제 금액"
+        price={`${totalPrice.toLocaleString()}원`}
+        font="font-bold"
+        text="text-20"
+        color={color}
+      />
+      {checkbox && (
+        <TermsCheckbox
+          entire="전체동의(필수)"
+          checkContent={REQUIRED_FOR_PAYMENT}
+          useFormContextProps={false}
+          showLastButton={false}
+          onCheckedChange={handleCheckedChange}
         />
-        <TotalPrice
-          title="총 배송비"
-          price={`${delivery.toLocaleString()}원`}
-        />
-        <TotalPrice
-          title="총 할인 금액"
-          price={`${discount.toLocaleString()}원`}
-        />
-        <TotalPrice
-          title="결제 금액"
-          price={`${totalPrice.toLocaleString()}원`}
-          font="font-bold"
-          text="text-20"
-          color={color}
-        />
-        <form onSubmit={handleSubmit(onSubmit)}>
-          {checkbox && (
-            <TermsCheckbox
-              entire="전체동의(필수)"
-              checkContent={REQUIRED_FOR_PAYMENT}
-              useFormContextProps={false}
-              showLastButton={false}
-              onCheckedChange={handleCheckedChange}
-            />
-          )}
-          {button && <PaymentButton disabled={!isAllChecked} />}
-        </form>
-      </div>
-    </FormProvider>
+      )}
+      {button && <PaymentButton isAllChecked={isAllChecked} />}
+    </div>
   );
 }
 

--- a/src/components/container/terms/terms.tsx
+++ b/src/components/container/terms/terms.tsx
@@ -10,6 +10,7 @@ interface TermsCheckboxProps {
   checkContent: string[];
   useFormContextProps?: boolean;
   showLastButton?: boolean;
+  onCheckedChange?: (checkedStates: boolean) => void;
 }
 interface CheckedStates {
   [key: string]: boolean;
@@ -21,6 +22,7 @@ function TermsCheckbox({
   checkContent,
   useFormContextProps = true,
   showLastButton = true,
+  onCheckedChange,
 }: TermsCheckboxProps) {
   const formMethods = useFormContextProps ? useFormContext() : null;
 
@@ -47,6 +49,7 @@ function TermsCheckbox({
   useEffect(() => {
     const isAllChecked = Object.values(checkedStates).every(Boolean);
     formMethods?.setValue('selectAll', isAllChecked);
+    if (onCheckedChange) onCheckedChange(isAllChecked);
   }, [checkedStates, formMethods?.setValue]);
 
   return (
@@ -67,8 +70,8 @@ function TermsCheckbox({
             {...formMethods?.register('selectAll')}
             checked={Object.values(checkedStates).every(Boolean)}
             onChange={handleSelectAll}
-            className="mt-0.5 checked:bg-primary relative float-left mr-8 h-20 w-20 appearance-none rounded-[2px] border-2
-              border-solid border-gray-3 p-1 checked:border-0"
+            className="mt-0.5 relative float-left mr-8 h-20 w-20 appearance-none rounded-[2px] border-2 border-solid
+              border-gray-3 p-1 checked:border-0 checked:bg-primary"
           />
           {entire}
         </label>
@@ -96,8 +99,8 @@ function TermsCheckbox({
                   type="checkbox"
                   checked={checkedStates[content]}
                   onChange={() => handleIndividualCheck(content)}
-                  className="mt-0.5 checked:bg-primary relative float-left mr-8 h-20 w-20 appearance-none rounded-[2px] border-2
-                    border-solid border-gray-3 p-1 checked:border-0"
+                  className="mt-0.5 relative float-left mr-8 h-20 w-20 appearance-none rounded-[2px] border-2 border-solid
+                    border-gray-3 p-1 checked:border-0 checked:bg-primary"
                 />
                 {content}
               </label>

--- a/src/components/dropDown/deliveryDropDown.tsx
+++ b/src/components/dropDown/deliveryDropDown.tsx
@@ -24,7 +24,7 @@ function DeliveryDropDown() {
   };
 
   return (
-    <div className="z-10 flex w-full flex-col gap-y-12">
+    <div className="flex w-full flex-col gap-y-12">
       <DropDown
         menus={DELIVERY_MENU}
         selectedItem={selectedItem}

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -1,4 +1,3 @@
-import RegisterButton from '@/components/button/register/registerButton';
 import ShippingAddressSection from '@/components/container/shippingAddressSection/shippingAddressSection';
 import BookPaymentCardList from '@/components/card/bookPaymentCard/bookPaymentCardList';
 import { ReactElement } from 'react';
@@ -6,14 +5,13 @@ import MainLayout from '@/components/layout/mainLayout';
 import TotalPriceCard from '@/components/card/totalPaymentCard';
 import { basketItemList } from '@/store/state';
 import { useAtomValue } from 'jotai';
-import PaymentButton from '@/components/button/payment/paymentButton';
 
 export default function Order() {
   const items = useAtomValue(basketItemList);
 
   return (
     <div className="flex w-full justify-center">
-      <div className=" flex h-full w-full justify-center mobile:flex-col tablet:flex-col pc:gap-x-93">
+      <div className=" flex h-full w-full justify-center mobile:flex-col tablet:flex-col">
         <div className="flex-center mx-60 flex-col pc:mb-[603px]">
           <ShippingAddressSection />
 
@@ -21,11 +19,9 @@ export default function Order() {
             <BookPaymentCardList bookData={items} label="주문 상품" />
           </div>
         </div>
-        <div className="sticky top-100 mx-40 mb-180 mobile:relative tablet:relative">
+        <div className="sticky top-100 mx-40 mb-180 tablet:mt-100">
           <TotalPriceCard />
         </div>
-
-        {/* <PaymentButton type="mobile" /> */}
       </div>
     </div>
   );

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -21,11 +21,11 @@ export default function Order() {
             <BookPaymentCardList bookData={items} label="주문 상품" />
           </div>
         </div>
-        <div className="sticky top-177 mx-40 mb-180 mobile:mt-80 tablet:mt-80">
+        <div className="sticky top-100 mx-40 mb-180 mobile:relative tablet:relative">
           <TotalPriceCard />
         </div>
 
-        <PaymentButton type="mobile" />
+        {/* <PaymentButton type="mobile" /> */}
       </div>
     </div>
   );


### PR DESCRIPTION
## 구현사항

삽질을 너무 오래해서 시간이 많이걸렸습니다 ㅠㅠ 죄송해용..

- 결제버튼을 한 곳에서만 사용하도록 수정했습니다.
( 모바일/태블릿 에서는 하단 fixed로 고정되도록 변경했습니다.)

- 버튼을 수정하면서 연결된 컴포넌트에서 자잘한 style 수정이 있었습니다.
- 모든 약관체크가 완료되어야 handlePaymentButtonClick 함수가 작동하도록 수정했습니다.

## 사용방법

- useFormContext가 있어서 useForm을 부모컴포넌트에서 사용해보려고 했으나, 부모에서 selectAll값이 안불러와지더라구용..
이미 만들어진 연아님의 signup 컴포넌트를 참고해서 도전해봤지만 실패해서 다른방법을 썼습니다.

### Terms 컴포넌트
부모에서 받아온 onCheckedChange함수에 체크값이 변할때마다 isAllChecked값을 실어 올려줍니다.
![스크린샷 2024-02-23 오후 12 19 17](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/766111f8-fe27-4209-aeb0-ad8f5b254486)

### TotalPriceCard 컴포넌트
Terms에서 받아온 값으로 state를 변경하여 결제버튼에 해당 boolean 값을 넘겨줍니다.
![스크린샷 2024-02-23 오후 12 22 35](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/455d90f8-856b-4504-b580-f59a9dec7f79)
![스크린샷 2024-02-23 오후 12 23 19](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/ad31d43e-fb36-44f2-9331-321247c2968b)

### PaymentButton 컴포넌트
TotalPriceCard에서 받은 boolean 값을 조건으로 결제함수 실행 or 토스트 에러메시지 표시를 진행합니다.
![스크린샷 2024-02-23 오후 12 23 46](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/28276e58-089c-46a8-9f16-63eed3a9c2c4)



## 스크린샷


https://github.com/bookstore-README/front_bookstore-README/assets/120437902/18b25212-a8fe-4881-84cc-6f64577868d2


##### close #350 
