### PR TITLE
[#377] customsection get 요청에 enabled 옵션 추가

### DIFF
--- a/src/components/container/customSection/customSection.tsx
+++ b/src/components/container/customSection/customSection.tsx
@@ -23,6 +23,7 @@ function CustomSection({ isLoggedIn }: CustomSectionProps) {
     queryFn: () => getCustomCategoryList(),
     select: (data) => data.data,
     staleTime: Infinity,
+    enabled: isLoggedIn,
   });
 
   const genreList = useMemo(() => {


### PR DESCRIPTION
## 구현사항
#377 과 같이 미로그인 상태에서도 get요청을 보내 403에러가 발생했습니다. 작동에서는 문제가 없어 늦게 파악했네요.
<img width="1116" alt="스크린샷 2024-02-25 오전 1 04 25" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/83effc2f-1673-4311-8230-ecf1cad5b2c9">

- [x] customsection get 요청에 enabled 옵션 추가

## 사용방법
[] 미로그인 상태에서 main page에 접속했을 때 위의 이미지와 같은 이유로 403에러가 발생하지 않는지 확인해주세요.


##### close #377
