### PR TITLE
[#384] 카테고리 페이지 베스트셀러 디자인 일부 수정

### DIFF
--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -13,6 +13,10 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
     page === 'main'
       ? 'tablet:mx-40  tablet:w-[690px] mobile:mx-15 pc:w-[1080px] tablet:my-120 pc:my-120'
       : 'pc:w-[895px] tablet:w-[511px]';
+  const gapXClass =
+    page === 'main'
+      ? 'pc:gap-x-30 tablet:gap-x-20 mobile:gap-x-10'
+      : ' pc:gap-x-20 tablet:gap-x-20 mobile:gap-x-10';
 
   return (
     <div
@@ -20,11 +24,14 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
         `}>
       <div className="flex justify-between mobile:mb-20 tablet:mb-40 pc:mb-50">
         <div className="text-20 font-bold">베스트셀러</div>
-        <Link href="/domestic/bestseller" className="text-primary">
-          더보기
-        </Link>
+        {page === 'main' && (
+          <Link href="/domestic/bestseller" className="text-primary">
+            더보기
+          </Link>
+        )}
       </div>
-      <div className="flex-center flex flex-wrap justify-start gap-x-10 gap-y-62 overflow-auto mobile:hidden tablet:hidden pc:gap-x-30">
+      <div
+        className={`flex-center flex flex-wrap justify-start gap-y-62 overflow-auto mobile:hidden tablet:hidden ${gapXClass}`}>
         {bookList?.map((book, index) => (
           <PreviewBookInfo
             key={book.bookId}
@@ -37,7 +44,8 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
           />
         ))}
       </div>
-      <div className="flex-center flex flex-wrap justify-start gap-x-10 gap-y-62 tablet:hidden pc:hidden pc:gap-x-30">
+      <div
+        className={`flex-center flex flex-wrap justify-start gap-y-62 tablet:hidden pc:hidden ${gapXClass}`}>
         {bookList?.map((book, index) => (
           <PreviewBookInfo
             key={book.bookId}
@@ -51,7 +59,8 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
         ))}
       </div>
 
-      <div className="flex w-full flex-wrap justify-start gap-x-20 gap-y-62 mobile:hidden pc:hidden">
+      <div
+        className={`flex w-full flex-wrap justify-start gap-y-62 mobile:hidden pc:hidden ${gapXClass}`}>
         {bookList?.map((book, index) => (
           <PreviewBookInfo
             key={book.bookId}

--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -16,7 +16,7 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
   const gapXClass =
     page === 'main'
       ? 'pc:gap-x-30 tablet:gap-x-20 mobile:gap-x-10'
-      : ' pc:gap-x-20 tablet:gap-x-20 mobile:gap-x-10';
+      : ' pc:gap-x-20 tablet:gap-x-15 mobile:gap-x-10';
 
   return (
     <div
@@ -64,7 +64,7 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
         {bookList?.map((book, index) => (
           <PreviewBookInfo
             key={book.bookId}
-            size={'sm'}
+            size={page === 'main' ? 'sm' : 'lg'}
             title={book.bookTitle}
             image={book.bookImgUrl}
             authorList={book.authors}

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -14,7 +14,7 @@ import { AdImage, EVENT_IMAGES } from '@/constants/eventImages';
 function CategoryPage() {
   const INITIAL_PARAMS = useCategoryCarouselParams();
   const { categoryId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: {
       ...INITIAL_PARAMS,
@@ -41,7 +41,7 @@ function CategoryPage() {
         eventImgs={EVENT_IMAGES}
       />
       <Spacing height={[60, 40, 40]} />
-      {data && data?.data.books.length > 0 ? (
+      {data && data?.data.books.length > 0 && !isLoading ? (
         <>
           <CategoryCarousel data={data?.data.books} responsive={responsive} />
           <Spacing height={[120, 80, 80]} />
@@ -49,9 +49,13 @@ function CategoryPage() {
           <Spacing height={[120, 80, 80]} />
           <SubCategoryBookList />
         </>
-      ) : (
+      ) : (!data || data?.data.books.length <= 0) && !isLoading ? (
         <div className="flex-center w-full pt-120 text-gray-4 mobile:pt-80">
           이 카테고리에 등록된 도서가 없어요!
+        </div>
+      ) : (
+        <div className="flex-center w-full pt-120 text-gray-4 mobile:pt-80">
+          도서 찾는 중!
         </div>
       )}
     </SidebarLayout>

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -14,7 +14,7 @@ import { AdImage, EVENT_IMAGES } from '@/constants/eventImages';
 function CategoryPage() {
   const INITIAL_PARAMS = useCategoryCarouselParams();
   const { categoryId } = useCheckCategoryUrl();
-  const { data } = useGetBook({
+  const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: {
       ...INITIAL_PARAMS,
@@ -48,9 +48,13 @@ function CategoryPage() {
           <Spacing height={[120, 80, 80]} />
           <SubCategoryBookList />
         </>
-      ) : (
+      ) : (!data || data?.data.books.length <= 0) && !isLoading ? (
         <div className="flex-center w-full pt-120 text-gray-4 mobile:pt-80">
           이 카테고리에 등록된 도서가 없어요!
+        </div>
+      ) : (
+        <div className="flex-center w-full pt-120 text-gray-4 mobile:pt-80">
+          도서 찾는 중!
         </div>
       )}
     </SidebarLayout>


### PR DESCRIPTION
## 구현사항

카테고리 페이지 중간 베스트셀레 섹션 책 간 간격을 조절했습니다. 

-[] 구현한 내용 및 설명

## 사용방법

카테고리 페이지에 들어가면 볼 수 있습니다!!

## 스크린샷

수정 후 버전: 데탑에선 5열, 타블렛에선 3열, 모바에선 2열로 잘 나옵니다!!

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/e3a1ea68-e826-4ce0-809f-c9f91d743c8d)

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/5dc7017a-e106-449c-a1db-946cdd2fb80f)

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/6164b10c-400e-4fb9-a8c1-17b868653c6e)


##### close #384