### PR TITLE
[#401] 도서 컴포넌트 저자명 표시 방식 변경

### DIFF
--- a/src/components/book/bookAuthor/bookAuthor.tsx
+++ b/src/components/book/bookAuthor/bookAuthor.tsx
@@ -1,6 +1,6 @@
 /* string 배열형 author 값을 받아 author 리스트를 출력하는 컴포넌트
  */
-
+import useEditAuthorsName from '@/hooks/common/useEditAutorsName';
 interface BookAuthorProps {
   authorList?: string[] | null;
   publisher?: string;
@@ -14,15 +14,14 @@ function BookAuthor({
   fontSize,
   classNames,
 }: BookAuthorProps) {
-  if (!authorList || authorList.length < 1) return null;
-
-  let nameList = authorList.join(', ');
+  let nameList = authorList?.join(', ');
   nameList += publisher ? ` | ${publisher}` : '';
+  const authors = useEditAuthorsName(nameList);
   return (
     <div
       className={`${classNames ?? ``} text-14 text-gray-3`}
       style={{ fontSize: fontSize }}>
-      {nameList}
+      {authors}
     </div>
   );
 }

--- a/src/components/book/bookAuthor/bookAuthor.tsx
+++ b/src/components/book/bookAuthor/bookAuthor.tsx
@@ -1,11 +1,12 @@
 /* string 배열형 author 값을 받아 author 리스트를 출력하는 컴포넌트
  */
-import useEditAuthorsName from '@/hooks/common/useEditAutorsName';
+import useEditAuthorsName from '@/hooks/common/useEditAuthorsName';
 interface BookAuthorProps {
-  authorList?: string[] | null;
+  authorList?: string[] | null | string;
   publisher?: string;
   fontSize?: number;
   classNames?: string;
+  isDetail?: boolean;
 }
 
 function BookAuthor({
@@ -13,10 +14,14 @@ function BookAuthor({
   publisher,
   fontSize,
   classNames,
+  isDetail,
 }: BookAuthorProps) {
-  let nameList = authorList?.join(', ');
+  let nameList = Array.isArray(authorList)
+    ? authorList?.join(', ')
+    : authorList;
   nameList += publisher ? ` | ${publisher}` : '';
-  const authors = useEditAuthorsName(nameList);
+  const authors = useEditAuthorsName({ authors: nameList, isDetail: isDetail });
+  console.log('author' + authorList);
   return (
     <div
       className={`${classNames ?? ``} text-14 text-gray-3`}

--- a/src/components/book/previewBookInfo/authors.tsx
+++ b/src/components/book/previewBookInfo/authors.tsx
@@ -1,3 +1,4 @@
+import useEditAuthorsName from '@/hooks/common/useEditAutorsName';
 interface BookAuthorsProps {
   alignCenter?: boolean;
   authorList: string[];
@@ -6,8 +7,8 @@ interface BookAuthorsProps {
 function BookAuthors({ alignCenter, authorList }: BookAuthorsProps) {
   return (
     <div
-      className={`text-gray-3 text-14 truncate ${alignCenter ? 'text-center' : ''}`}>
-      {authorList.join(', ')}
+      className={`truncate text-14 text-gray-3 ${alignCenter ? 'text-center' : ''}`}>
+      {useEditAuthorsName(authorList.join(', '))}
     </div>
   );
 }

--- a/src/components/book/previewBookInfo/authors.tsx
+++ b/src/components/book/previewBookInfo/authors.tsx
@@ -1,4 +1,4 @@
-import useEditAuthorsName from '@/hooks/common/useEditAutorsName';
+import useEditAuthorsName from '@/hooks/common/useEditAuthorsName';
 interface BookAuthorsProps {
   alignCenter?: boolean;
   authorList: string[];

--- a/src/components/book/previewBookInfo/authors.tsx
+++ b/src/components/book/previewBookInfo/authors.tsx
@@ -8,7 +8,7 @@ function BookAuthors({ alignCenter, authorList }: BookAuthorsProps) {
   return (
     <div
       className={`truncate text-14 text-gray-3 ${alignCenter ? 'text-center' : ''}`}>
-      {useEditAuthorsName(authorList.join(', '))}
+      {useEditAuthorsName({ authors: authorList.join(', ') })}
     </div>
   );
 }

--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -1,5 +1,6 @@
 /** 책 상세페이지에 들어갈 카드 컴포넌트 */
 
+import useEditAuthorsName from '@/hooks/common/useEditAuthorsName';
 import BookDetailImg from './bookDetailImg';
 import BookDetailInfo from './bookDetailInfo';
 import StaticOrderNavigator from '@/components/orderNavigator/staticOrderNavigator';
@@ -21,6 +22,7 @@ interface BookDetailCardProps {
   reviewCount: number;
   orderCount: number;
   setOrderCount: (n: number) => void;
+  isDetail?: boolean | undefined;
 }
 
 function BookDetailCard({
@@ -40,7 +42,14 @@ function BookDetailCard({
   reviewCount,
   orderCount,
   setOrderCount,
+  isDetail,
 }: BookDetailCardProps) {
+  const authorList = useEditAuthorsName({
+    authors: authors,
+    isDetail: isDetail,
+  });
+
+  console.log('authors' + authorList);
   return (
     <section className="mobile:flex-center flex items-start justify-start gap-20 mobile:flex-col">
       <BookDetailImg imageUrl={bookImgUrl} />
@@ -51,7 +60,7 @@ function BookDetailCard({
           bookId={bookId}
           bookTitle={bookTitle}
           categories={categories}
-          authors={authors}
+          authors={authorList}
           isBookmarked={isBookmarked}
           isBookmarkPending={isBookmarkPending}
           handleBookmarkClick={handleBookmarkClick}
@@ -61,6 +70,7 @@ function BookDetailCard({
           averageRating={averageRating}
           reviewCount={reviewCount}
           price={price}
+          isDetail={isDetail}
         />
         <StaticOrderNavigator
           bookId={bookId}

--- a/src/components/card/bookDetailCard/bookDetailInfo.tsx
+++ b/src/components/card/bookDetailCard/bookDetailInfo.tsx
@@ -8,6 +8,7 @@ import Spacing from '@/components/container/spacing/spacing';
 import BookAuthor from '@/components/book/bookAuthor/bookAuthor';
 import useFormatDate from '@/hooks/useFormatDate';
 import useCopyLink from '@/hooks/common/useCopyLink';
+import useEditAuthorsName from '@/hooks/common/useEditAuthorsName';
 
 interface BookDetailInfoProps {
   bookId: string;
@@ -16,13 +17,14 @@ interface BookDetailInfoProps {
   isBookmarked: boolean;
   handleBookmarkClick: () => void;
   bookmarkCount: number;
-  authors?: string[];
+  authors?: string[] | string;
   publisher?: string;
   publishedDate: string;
   averageRating: number;
   isBookmarkPending: boolean;
   reviewCount: number;
   price: number;
+  isDetail: boolean | undefined;
 }
 
 function BookDetailInfo({
@@ -39,10 +41,11 @@ function BookDetailInfo({
   averageRating,
   reviewCount,
   price,
+  isDetail,
 }: BookDetailInfoProps) {
   const customedPublishedDate = useFormatDate(publishedDate);
   const { copyURL } = useCopyLink();
-
+  const authorList = useEditAuthorsName({ authors, isDetail });
   return (
     <article
       role="info"
@@ -70,7 +73,7 @@ function BookDetailInfo({
         </div>
       </div>
       <Spacing height={[12, 12, 12]} />
-      <BookAuthor authorList={authors} />
+      <BookAuthor authorList={authorList} isDetail={isDetail} />
       <div className="my-20 h-[1px] w-full max-w-[525px] bg-gray-1 mobile:my-12"></div>
       <div className="text-14 text-gray-3">
         {publisher} | {customedPublishedDate}

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -14,7 +14,7 @@ import { useSetAtom } from 'jotai';
 import { PayMentAtom } from '@/types/cartType';
 import { basketItemList } from '@/store/state';
 import { useUpdateBookmark } from '@/hooks/api/useUpdateBookmark';
-import useEditAuthorsName from '@/hooks/common/useEditAutorsName';
+import useEditAuthorsName from '@/hooks/common/useEditAuthorsName';
 
 function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const [isBookmarked, setIsBookMarked] = useState(book.bookmarks?.marked);

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -24,7 +24,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const { addToBasket, isAddToBasketPending } = useAddToBasket({
     bookId: book.bookId,
   });
-  const authors = useEditAuthorsName(book?.authors);
+  const authors = useEditAuthorsName({ authors: book?.authors });
   const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
     bookId: book.bookId,
     onChangeBookmarkCount: () => {

--- a/src/components/card/bookOverviewCard/bookOverViewCard.tsx
+++ b/src/components/card/bookOverviewCard/bookOverViewCard.tsx
@@ -14,6 +14,7 @@ import { useSetAtom } from 'jotai';
 import { PayMentAtom } from '@/types/cartType';
 import { basketItemList } from '@/store/state';
 import { useUpdateBookmark } from '@/hooks/api/useUpdateBookmark';
+import useEditAuthorsName from '@/hooks/common/useEditAutorsName';
 
 function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const [isBookmarked, setIsBookMarked] = useState(book.bookmarks?.marked);
@@ -23,7 +24,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
   const { addToBasket, isAddToBasketPending } = useAddToBasket({
     bookId: book.bookId,
   });
-
+  const authors = useEditAuthorsName(book?.authors);
   const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
     bookId: book.bookId,
     onChangeBookmarkCount: () => {
@@ -92,13 +93,7 @@ function BookOverviewCard({ book, rank }: BookOverviewType2) {
             role="book-author-publisher"
             className="pc:flex-center gap-4 mobile:flex mobile:flex-col tablet:flex tablet:w-150 tablet:flex-col">
             <div className="text-overflow1">
-              {book.authors?.map((author) => {
-                return (
-                  <span key={author} className="text-14 text-gray-3">
-                    {author}
-                  </span>
-                );
-              })}
+              <span className="text-14 text-gray-3">{authors}</span>
             </div>
             <div className="text-overflow1 mobile:hidden tablet:hidden">
               {book.publisher && (

--- a/src/hooks/common/useEditAuthorsName.ts
+++ b/src/hooks/common/useEditAuthorsName.ts
@@ -1,4 +1,9 @@
-function useEditAuthorsName(authors: string | undefined | string[]) {
+interface useEditAuthorsNameProps {
+  authors: string | string[] | undefined | null;
+  isDetail?: boolean | undefined;
+}
+
+function useEditAuthorsName({ authors, isDetail }: useEditAuthorsNameProps) {
   // authors가 문자열 또는 배열이 아닌 경우 빈 문자열을 반환합니다.
   if (!authors || (typeof authors !== 'string' && !Array.isArray(authors))) {
     return '';
@@ -9,7 +14,8 @@ function useEditAuthorsName(authors: string | undefined | string[]) {
     const index = authors.indexOf('('); // '(' 문자의 인덱스를 찾습니다.
     if (index !== -1) {
       // 만약 '(' 문자가 존재한다면
-      return authors.substring(0, index); // 문자열의 처음부터 '(' 이전까지의 부분 문자열을 반환합니다.
+      const editedAuthor = authors.substring(0, index); // 문자열의 처음부터 '(' 이전까지의 부분 문자열을 반환합니다.
+      return isDetail ? `${editedAuthor} 지음` : editedAuthor;
     } else {
       // 만약 '(' 문자가 존재하지 않는다면
       return authors; // 주어진 문자열 그대로 반환합니다.
@@ -18,11 +24,18 @@ function useEditAuthorsName(authors: string | undefined | string[]) {
 
   // 배열인 경우
   const editedAuthors: string[] = [];
-  for (const author of authors) {
+  for (let i = 0; i < authors.length; i++) {
+    const author = authors[i];
     const index = author.indexOf('('); // '(' 문자의 인덱스를 찾습니다.
     if (index !== -1) {
       // 만약 '(' 문자가 존재한다면
-      editedAuthors.push(author.substring(0, index)); // 문자열의 처음부터 '(' 이전까지의 부분 문자열을 배열에 추가합니다.
+      const editedAuthor = author.substring(0, index); // 문자열의 처음부터 '(' 이전까지의 부분 문자열을 배열에 추가합니다.
+      if (i === authors.length - 1) {
+        // 마지막 요소인 경우
+        editedAuthors.push(isDetail ? `${editedAuthor} 지음` : editedAuthor);
+      } else {
+        editedAuthors.push(editedAuthor);
+      }
     } else {
       // 만약 '(' 문자가 존재하지 않는다면
       editedAuthors.push(author); // 주어진 문자열을 배열에 추가합니다.

--- a/src/hooks/common/useEditAutorsName.ts
+++ b/src/hooks/common/useEditAutorsName.ts
@@ -1,0 +1,34 @@
+function useEditAuthorsName(authors: string | undefined | string[]) {
+  // authors가 문자열 또는 배열이 아닌 경우 빈 문자열을 반환합니다.
+  if (!authors || (typeof authors !== 'string' && !Array.isArray(authors))) {
+    return '';
+  }
+
+  // 문자열인 경우
+  if (typeof authors === 'string') {
+    const index = authors.indexOf('('); // '(' 문자의 인덱스를 찾습니다.
+    if (index !== -1) {
+      // 만약 '(' 문자가 존재한다면
+      return authors.substring(0, index); // 문자열의 처음부터 '(' 이전까지의 부분 문자열을 반환합니다.
+    } else {
+      // 만약 '(' 문자가 존재하지 않는다면
+      return authors; // 주어진 문자열 그대로 반환합니다.
+    }
+  }
+
+  // 배열인 경우
+  const editedAuthors: string[] = [];
+  for (const author of authors) {
+    const index = author.indexOf('('); // '(' 문자의 인덱스를 찾습니다.
+    if (index !== -1) {
+      // 만약 '(' 문자가 존재한다면
+      editedAuthors.push(author.substring(0, index)); // 문자열의 처음부터 '(' 이전까지의 부분 문자열을 배열에 추가합니다.
+    } else {
+      // 만약 '(' 문자가 존재하지 않는다면
+      editedAuthors.push(author); // 주어진 문자열을 배열에 추가합니다.
+    }
+  }
+  return editedAuthors;
+}
+
+export default useEditAuthorsName;

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -90,6 +90,7 @@ export default function BookDetailPage() {
             reviewCount={bookData.reviewCount}
             orderCount={orderCount}
             setOrderCount={setOrderCount}
+            isDetail={true}
           />
         )}
       </section>


### PR DESCRIPTION
## 구현사항
디자인 상 (지은이) 를 표시하지 않게 되어있는데 구현 페이지 상에선 표시하길래 제외하도록 하는 훅을 만들어 적용해보았습니다! 그리고 상세 페이지의 경우 지은이 이름 끝에 '지음' 이 붙길래 그것도 예외처리를 해봤어요.

## 변경 전
<img width="1138" alt="스크린샷 2024-02-26 오후 5 19 07" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/0c429cac-0231-4ea6-a300-0d5415071df6">

<img width="574" alt="스크린샷 2024-02-26 오후 6 28 44" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/50cf1a72-ed80-4ca3-ba43-0f7aa49c45a8">


## 변경 후
<img width="1123" alt="스크린샷 2024-02-26 오후 5 18 31" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/cf1b5472-bf48-468e-9816-262fea1d3251">
<img width="490" alt="스크린샷 2024-02-26 오후 5 40 22" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/7e207617-b834-4774-999c-3abc9a2da271">

<img width="578" alt="스크린샷 2024-02-26 오후 6 28 10" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/c29a5488-0df1-42da-a83e-b4845bbf9740">

## 사용방법
- [] 메인페이지/카테고리페이지/베스트페이지 등에서 도서 컴포넌트가 (지은이) 부분 제외하고 저자명만 표시되나요?
## 스크린샷

##### close #401
