### PR TITLE
[#358] 소셜 로그인 기능 구현

### DIFF
--- a/src/components/chip/socialCircle.tsx
+++ b/src/components/chip/socialCircle.tsx
@@ -9,11 +9,7 @@ import Link from 'next/link';
 
 function SocialCircle({ id = 'KAKAO', width = 36, height = 36 }) {
   /*
-  TODO
-    이후 성공하면 code 값 받아서 getSocialLogin(id) 로 get,
-    실패하면 return 하는 api 처리 훅 짜기. 이때 useFetch 훅을 써서 onSuccess로 연결.
-    그리고 getSocialLogin까지 성공하면 받은 토큰과 유저 데이터를 
-    session에 저장하는 코드까지 짜고 확인하기
+  TODO session에 저장하는 코드까지 짜고 확인하기
   */
   const authLink =
     id === 'KAKAO'
@@ -23,8 +19,6 @@ function SocialCircle({ id = 'KAKAO', width = 36, height = 36 }) {
         : id === 'Google'
           ? process.env.NEXT_PUBLIC_GOOGLE_AUTH_LINK!
           : '/';
-  console.log("authLink: ", authLink);
-  console.log("process 체크: ", process.env.NEXT_PUBLIC_KAKAO_AUTH_LINK);
 
   return (
     <Link

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -31,6 +31,24 @@ export default NextAuth({
         }
       },
     }),
+    CredentialsProvider({
+      id: 'social-credentials',
+      name: 'credentials',
+      type: 'credentials',
+      credentials: {
+        email: { type: 'text' },
+        socialType: { type: 'text' },
+        memberId: { type: 'text' },
+        accessToken: {type: "text"},
+      },
+      async authorize(credentials): Promise<any> {
+        if (!credentials?.accessToken) { throw new Error('Wrong User');}
+        return {
+          accessToken: credentials?.accessToken,
+          memberId: credentials?.memberId, 
+        };
+      },
+    }),
   ],
   callbacks: {
     async signIn({ user }) {

--- a/src/pages/signin/[socialType].tsx
+++ b/src/pages/signin/[socialType].tsx
@@ -5,13 +5,14 @@ import { useRouter } from "next/router";
 function SocialPage() {
   const router = useRouter();
   const { socialType, code } = router.query;
-  // const myType: SocialType = socialType === "kakao" ? "KAKAO" : socialType === "google" ? "GOOGLE" : "NAVER";
+  const myType: SocialType = socialType === "kakao" ? "KAKAO" : socialType === "google" ? "GOOGLE" : "NAVER";
   const { data } = useQuery({
     queryKey: [""],
-    queryFn: () => getSocialLogin(socialType as SocialType, code as string),
+    queryFn: () => getSocialLogin(myType, code as string),
     enabled: !!socialType
   })
   console.log(data);
+
   return (
     <div>로그인 중이에요~!! 잠시만용...<></></div>
   )

--- a/src/pages/signin/[socialType].tsx
+++ b/src/pages/signin/[socialType].tsx
@@ -37,7 +37,6 @@ function SocialPage() {
   useEffect(() => {
     handleSocialLogin();
   }, []);
-
   return;
 }
 

--- a/src/pages/signin/[socialType].tsx
+++ b/src/pages/signin/[socialType].tsx
@@ -1,21 +1,44 @@
-import { SocialType, getSocialLogin } from "@/api/social";
-import { useQuery } from "@tanstack/react-query";
-import { useRouter } from "next/router";
+import { SocialType, getSocialLogin } from '@/api/social';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { signIn } from 'next-auth/react';
+import { useEffect } from 'react';
 
 function SocialPage() {
   const router = useRouter();
   const { socialType, code } = router.query;
-  const myType: SocialType = socialType === "kakao" ? "KAKAO" : socialType === "google" ? "GOOGLE" : "NAVER";
-  const { data } = useQuery({
-    queryKey: [""],
-    queryFn: () => getSocialLogin(myType, code as string),
-    enabled: !!socialType
-  })
-  console.log(data);
+  const myType: SocialType =
+    socialType === 'kakao'
+      ? 'KAKAO'
+      : socialType === 'google'
+        ? 'GOOGLE'
+        : 'NAVER';
 
-  return (
-    <div>로그인 중이에요~!! 잠시만용...<></></div>
-  )
+  const { data } = useQuery({
+    queryKey: [''],
+    queryFn: () => getSocialLogin(myType, code as string),
+    enabled: !!socialType,
+    retry: 3,
+  });
+
+  const handleSocialLogin = async () => {
+    const result = await signIn('social-credentials', {
+      email: data?.email,
+      socialType: myType,
+      memberId: data?.memberId,
+      accessToken: data?.Authentication,
+      redirect: false,
+      callbackUrl: '/',
+    });
+    if (result && result?.url && typeof window !== 'undefined') {
+      window.location.href = result.url;
+    }
+  };
+  useEffect(() => {
+    handleSocialLogin();
+  }, []);
+
+  return;
 }
 
 export default SocialPage;


### PR DESCRIPTION
## 구현사항

### 테스트를 오로지 버셀 배포본에서만 할 수 있어서 저도... 어떻게 될지 잘 모르겠습니다, 머지 해봐야 알 수 있습니다...!!!

1. 일단 signin, signup 페이지의 카톡 구글 네이버 버튼을 누르면 각각 소셜 로그인 페이지로 이동하는 건 확인했습니다!
2. 로그인 버튼을 누르면 로그인되면서 다시 저희 페이지로 넘어와 토큰 발급 받는 것도 확인했습니다!!
3. 토큰값과 memberId, email 값들을 next-auth session에 저장하는 코드를 짜긴 했는데 될진 모르겠고 버셀 develop 브랜치에서 테스트해봐야 합니다...!!  일단 코드는 짰습니다!! 

-[] 구현한 내용 및 설명

## 사용방법

## 스크린샷

일단 소셜 로그인도 진행되고 토큰 값 받아오는 것도 확인했습니다!!! 

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/35ed073a-b8a5-42b7-a5e4-40c40e37719b)


##### close #358
