### PR TITLE
[#408] 제품상세페이지 디자인 수정 및 찜 개수 버그 수정

### DIFF
--- a/src/components/card/bookDetailCard/bookDetailCard.tsx
+++ b/src/components/card/bookDetailCard/bookDetailCard.tsx
@@ -12,7 +12,7 @@ interface BookDetailCardProps {
   price: number;
   categories: [string, string];
   authors: string[];
-  bookmarkCount: number;
+  bookmarkCount?: number;
   isBookmarked: boolean;
   handleBookmarkClick: () => void;
   publishedDate: string;

--- a/src/components/card/bookDetailCard/bookDetailInfo.tsx
+++ b/src/components/card/bookDetailCard/bookDetailInfo.tsx
@@ -16,7 +16,7 @@ interface BookDetailInfoProps {
   categories: [string, string];
   isBookmarked: boolean;
   handleBookmarkClick: () => void;
-  bookmarkCount: number;
+  bookmarkCount?: number;
   authors?: string[] | string;
   publisher?: string;
   publishedDate: string;

--- a/src/hooks/useClickBookmarkButton.ts
+++ b/src/hooks/useClickBookmarkButton.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useUpdateBookmark } from './api/useUpdateBookmark';
 
-function useClickBookmarkButton({bookId=0, marked=false, count=0}) {
+function useClickBookmarkButton({ bookId = 0, marked = false, count = 0 }) {
   const [isBookmarked, setIsBookMarked] = useState(marked);
   const [bookmarkCount, setBookmarkCount] = useState(count);
   
@@ -16,7 +16,6 @@ function useClickBookmarkButton({bookId=0, marked=false, count=0}) {
     },
     onChangeBookmarked: (prevState) => setIsBookMarked(prevState),
   });
-
   return {
     updateBookmark, isBookmarkPending, isBookmarked, bookmarkCount
   }

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -123,18 +123,20 @@ export default function BookDetailPage() {
           </div>
 
           <div className="hidden pc:flex pc:pt-50">
-            <SideOrderNavigator
-              bookId={bookId as string}
-              bookImgUrl={bookData?.bookImgUrl ?? './'}
-              bookTitle={bookData?.bookTitle}
-              authors={bookData?.authors}
-              isBookmarked={isBookmarked}
-              isBookmarkPending={isBookmarkPending}
-              handleBookmarkClick={updateBookmark}
-              price={bookData?.price ?? 0}
-              orderCount={orderCount}
-              setOrderCount={setOrderCount}
-            />
+            {location === 'information' && (
+              <SideOrderNavigator
+                bookId={bookId as string}
+                bookImgUrl={bookData?.bookImgUrl ?? './'}
+                bookTitle={bookData?.bookTitle}
+                authors={bookData?.authors}
+                isBookmarked={isBookmarked}
+                isBookmarkPending={isBookmarkPending}
+                handleBookmarkClick={updateBookmark}
+                price={bookData?.price ?? 0}
+                orderCount={orderCount}
+                setOrderCount={setOrderCount}
+              />
+            )}
           </div>
         </section>
 

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -15,7 +15,7 @@ import Spacing from '@/components/container/spacing/spacing';
 import SideOrderNavigator from '@/components/orderNavigator/sideOrderNavigator';
 import FooterOrderNavitgator from '@/components/orderNavigator/footerOrderNavitgator';
 import SkeletonBookDetailCard from '@/components/skeleton/bookDetailCard/skeleton';
-import useClickBookmarkButton from '@/hooks/useClickBookmarkButton';
+import { useUpdateBookmark } from '@/hooks/api/useUpdateBookmark';
 
 type BookDetailNavLocationType = 'information' | 'review' | 'currency';
 
@@ -46,12 +46,23 @@ export default function BookDetailPage() {
     enabled: status === 'authenticated',
   });
 
-  const { isBookmarked, bookmarkCount, isBookmarkPending, updateBookmark } =
-    useClickBookmarkButton({
-      bookId: Number(bookId),
-      marked: bookmarkData?.marked ?? false,
-      count: bookData?.bookmarkCount,
-    });
+  const [isBookmarked, setIsBookMarked] = useState(
+    bookmarkData?.isBookmarked ?? false,
+  );
+  const [bookmarkCount, setBookmarkCount] = useState(
+    data?.data.bookmarkCount ?? -1,
+  );
+  const { updateBookmark, isBookmarkPending } = useUpdateBookmark({
+    bookId: Number(bookId),
+    onChangeBookmarkCount: () => {
+      if (isBookmarked) {
+        setBookmarkCount(bookmarkCount - 1);
+      } else {
+        setBookmarkCount(bookmarkCount + 1);
+      }
+    },
+    onChangeBookmarked: (prevState) => setIsBookMarked(prevState),
+  });
 
   const { mutate: handleViewCountMutate } = usePutBook({
     bookId: Number(bookId),
@@ -81,8 +92,12 @@ export default function BookDetailPage() {
             price={bookData.price}
             categories={bookData.categories}
             authors={bookData.authors}
-            bookmarkCount={bookmarkCount}
-            isBookmarked={isBookmarked}
+            bookmarkCount={
+              bookmarkCount >= 0 ? bookmarkCount : bookData.bookmarkCount
+            }
+            isBookmarked={
+              bookmarkData ? bookmarkData.isBookmared : isBookmarked
+            }
             handleBookmarkClick={updateBookmark}
             publishedDate={bookData.publishedDate}
             publisher={bookData.publisher}


### PR DESCRIPTION
## 구현사항

1. 상세페이지 하단 제품상세 탭에서만 sideOrderComponent가 보이고, 교환환불 탭이나 리뷰 탭에선 안 보이게 수정함.
2. 상세페이지 찜 버튼 개수가 출력되지 않는 문제가 있어 수정함.

-[] 구현한 내용 및 설명

## 사용방법

제품 상세페이지에 들어가면 확인할 수 있습니다, 기능 수정은 없고 디자인만 수정했습니다!!

## 스크린샷

리뷰 탭에선 옆에 구매하기/장바구니 버튼 탭이 안 보이게 수정!

![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/f2ffa255-cb61-4225-b022-ad943aa3b878)


##### close #408
