### PR TITLE
[#436] 베스트셀러 섹션 스크롤 삭제

### DIFF
--- a/src/components/container/bestsellerSection/bestsellerSection.tsx
+++ b/src/components/container/bestsellerSection/bestsellerSection.tsx
@@ -31,7 +31,7 @@ function BestSellerSection({ page, bookList }: BestSellerSectionProps) {
         )}
       </div>
       <div
-        className={`flex-center flex flex-wrap justify-start gap-y-62 overflow-auto mobile:hidden tablet:hidden ${gapXClass}`}>
+        className={`flex-center flex flex-wrap justify-start gap-y-62 mobile:hidden tablet:hidden ${gapXClass}`}>
         {bookList?.map((book, index) => (
           <PreviewBookInfo
             key={book.bookId}


### PR DESCRIPTION
## 구현사항
overflow-auto 때문에 불필요한 스크롤이 생겨 삭제하였습니다.
- [x]  overflow-auto 삭제

## 사용방법
[] 메인페이지에서 베스트셀러 섹션에 스크롤이 없는지 확인해주세요.

## 변경 전

<img width="701" alt="스크린샷 2024-02-27 오후 6 24 10" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/40d0c188-c08f-4976-9a52-c4b0a45f28dd">

## 변경 후
<img width="695" alt="스크린샷 2024-02-27 오후 6 24 35" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/eb5ac7f4-5953-4aa1-a8a5-0fc50556d1f0">
##### close #436
