### PR TITLE
[#443] 책 상세페이지 디자인 일부 수정

### DIFF
--- a/src/components/book/percentage/reviewPercentageOverview.tsx
+++ b/src/components/book/percentage/reviewPercentageOverview.tsx
@@ -25,12 +25,12 @@ function ReviewPercentageOverview({
         return (
           <div key={ind} className="flex-center gap-20 mobile:gap-10">
             <div
-              className={`text-12 text-gray-2 ${major === ind + 1 ? 'text-primary font-bold' : ''}`}>
+              className={`text-12 text-gray-2 ${major === el ? 'font-bold text-primary' : ''}`}>
               {ind + 1} 점
             </div>
             <Percentage num={el} total={reviewNum} />
             <div
-              className={`text-12 text-gray-2 ${major === el ? 'text-secondary font-bold' : ''}`}>
+              className={`text-12 text-gray-2 ${major === el ? 'font-bold text-secondary' : ''}`}>
               {reviewNum === 0 ? 0 : Math.floor((el * 100) / reviewNum)} %
             </div>
           </div>

--- a/src/components/card/bookDetailCard/bookDetailInfo.tsx
+++ b/src/components/card/bookDetailCard/bookDetailInfo.tsx
@@ -49,7 +49,7 @@ function BookDetailInfo({
   return (
     <article
       role="info"
-      className="flex max-w-[525px] grow flex-col items-start justify-start mobile:w-full">
+      className="flex w-full grow flex-col items-start justify-start pc:w-[525px]">
       <BookCategory categories={categories} />
       <Spacing height={[4, 4, 4]} />
       <div className="flex w-full items-center justify-between gap-20">

--- a/src/components/review/review.tsx
+++ b/src/components/review/review.tsx
@@ -32,7 +32,7 @@ function Review({
   averageRating,
   reviewCount,
 }: ReviewProps) {
-  const [selectedOrder, setSelectedOrder] = useState('조회순');
+  const [selectedOrder, setSelectedOrder] = useState('최신순');
   const [currentOrder, setCurrentOrder] = useState(INITIAL_ORDER_STATUS);
   const [reviewCurrentPage] = useAtom(CurrentPageStateAtom);
 
@@ -79,7 +79,7 @@ function Review({
         className="flex w-full max-w-[710px] items-start justify-start text-20 font-bold
           text-gray-4 mobile:w-330">
         리뷰
-        <span className="text-primary pl-10 text-20 font-bold">
+        <span className="pl-10 text-20 font-bold text-primary">
           {reviewCount}
         </span>
       </h3>

--- a/src/pages/bookdetail/[bookId].tsx
+++ b/src/pages/bookdetail/[bookId].tsx
@@ -15,6 +15,8 @@ import SideOrderNavigator from '@/components/orderNavigator/sideOrderNavigator';
 import FooterOrderNavitgator from '@/components/orderNavigator/footerOrderNavitgator';
 import SkeletonBookDetailCard from '@/components/skeleton/bookDetailCard/skeleton';
 import { useUpdateBookmark } from '@/hooks/api/useUpdateBookmark';
+import { useAtom } from 'jotai';
+import { CurrentPageArrayIndexAtom, CurrentPageStateAtom } from '@/store/state';
 
 type BookDetailNavLocationType = 'information' | 'review' | 'currency';
 
@@ -27,6 +29,12 @@ export default function BookDetailPage() {
     useState<BookDetailNavLocationType>('information');
   // 책 구매 수량 state
   const [orderCount, setOrderCount] = useState(1);
+  const [currentPageArray, setCurrentPageArray] = useAtom(
+    CurrentPageArrayIndexAtom,
+  );
+  const [currentPageState, setCurrentPageState] = useAtom(CurrentPageStateAtom);
+  setCurrentPageArray(0);
+  setCurrentPageState(1);
 
   const { data, isLoading, isError } = useGetBook({
     endpoint: `${bookId}/detail`,


### PR DESCRIPTION
## 구현사항

상세페이지에서 일부 디자인 에러가 있어 수정했습니다!!

1.  책 제목이 짧은 경우 길이 안맞는 에러 수정
 (수정 전)
![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/ed6f2916-4f3e-49f9-bbb7-95f32f4258ee)

2. 리뷰 sort 드롭다운 메뉴 중 조회순이 있어서 제거.
(수정 전)
![image](https://github.com/bookstore-README/front_bookstore-README/assets/89698149/80ff91e5-2941-4c21-a16f-21d80af37524)

3. 페이지네이션 오류 수정

-[] 구현한 내용 및 설명

## 사용방법

제품 상세페이지에서 확인할 수 있습니다!! 디자인이나  기능 변경점은 하나도 없습니당. 

## 스크린샷

##### close #
