### PR TITLE
[#438] 커뮤니티 페이지 레이아웃 수정

### DIFF
--- a/src/components/card/communityCard/communityCardList.tsx
+++ b/src/components/card/communityCard/communityCardList.tsx
@@ -46,7 +46,7 @@ function CommunityCardList({
           );
         })
       ) : (
-        <div className="flex-center pt-100 mobile:pt-60">
+        <div className="flex-center pt-100 mobile:pt-60 w-full">
           작성한 커뮤니티글이 없어요!
         </div>
       )}

--- a/src/components/layout/communityLayout.tsx
+++ b/src/components/layout/communityLayout.tsx
@@ -22,7 +22,7 @@ function CommunityLayout({
   profile,
 }: CommunityLayoutProps) {
   const [ref, isIntersecting] = useInfinite();
-  const { data, hasNextPage, isRefetching } = useCustomInfiniteQuery({
+  const { data, hasNextPage, isLoading } = useCustomInfiniteQuery({
     endpoint: `${memberId ? `${memberId}` : ''}`,
     queryKey: ['community', `${memberId}`],
     queryFunc: getCommunity,
@@ -36,14 +36,16 @@ function CommunityLayout({
 
   return (
     <MainLayout>
-      <div className="mb-198 flex flex-col">
-        {isRefetching ? (
+      <div className="mb-198 flex w-[1200px] flex-col items-start mobile:w-[360px] tablet:mx-40 tablet:w-[768px]">
+        <PageTab
+          origin="피드"
+          originHref="/community"
+          add="내 글 보기"
+          addHref="/community/writeme"
+          isSelected={isSelected}
+        />
+        {isLoading ? (
           <>
-            <div className="mb-40 mt-20 flex h-27 w-169 items-center justify-between mobile:mb-27 mobile:mt-6 tablet:mb-36 tablet:mt-16">
-              <div className={`${SKELETON_COMMON_STYLE} h-27 w-40`} />
-              <div className={`${SKELETON_COMMON_STYLE} h-27 w-10`} />
-              <div className={`${SKELETON_COMMON_STYLE} h-27 w-70`} />
-            </div>
             <div className="mb-20 grid auto-rows-auto grid-cols-3 gap-20 mobile:grid-cols-1 tablet:grid-cols-2">
               {Array.from({
                 length: 6,
@@ -54,16 +56,8 @@ function CommunityLayout({
           </>
         ) : (
           <>
-            <PageTab
-              origin="피드"
-              originHref="/community"
-              add="내 글 보기"
-              addHref="/community/writeme"
-              isSelected={isSelected}
-            />
-            {
-              //@ts-ignore
-                <CommunityCardList communityData={data?.pages} kebab={kebab} profile={profile}/>
+            {//@ts-ignore
+              <CommunityCardList communityData={data?.pages} kebab={kebab} profile={profile}/>
             }
           </>
         )}

--- a/src/hooks/useCustomInfiniteQuery.ts
+++ b/src/hooks/useCustomInfiniteQuery.ts
@@ -30,7 +30,7 @@ function useCustomInfiniteQuery({
   getNextPageParamsFunc,
   selectFunc,
 }: useCustomInfiniteQueryProps) {
-  const { fetchNextPage, isFetchingNextPage, hasNextPage, isRefetching, data } =
+  const { fetchNextPage, isFetchingNextPage, hasNextPage, isRefetching, data, isLoading } =
     useInfiniteQuery({
       queryKey: [...queryKey],
       queryFn: ({ pageParam = initialCursorId }) => {
@@ -55,7 +55,7 @@ function useCustomInfiniteQuery({
     }
   }, [refetchTrigger, isRefetching, hasNextPage])
 
-  return {data, isFetchingNextPage, isRefetching, hasNextPage };
+  return {data, isFetchingNextPage, isRefetching, hasNextPage, isLoading };
 }
 
 export default useCustomInfiniteQuery


### PR DESCRIPTION
## 구현사항
- [x] isloading으로 커뮤니티 데이터 받아오기 전에는 스켈레톤만 보여주도록 변경
- [x] 데이터가 없는경우 탭 중앙정렬 -> 왼쪽 정렬로 수정 

## 스크린샷
(수정전)
<img width="1019" alt="스크린샷 2024-02-27 오후 6 26 41" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/d45d247b-7152-4d53-abc9-902d354dab45">
(수정후)

https://github.com/bookstore-README/front_bookstore-README/assets/138510303/1dd5530c-73b7-422d-9fe8-7570f5e6cb93


https://github.com/bookstore-README/front_bookstore-README/assets/138510303/612f3c69-432a-4458-a255-94afbb086b9f



##### close #438
