### PR TITLE
[#448] 글쓰기 모달 책 정렬 수정

### DIFF
--- a/src/components/modal/addCommunityCard/previewBookInfoPagination.tsx
+++ b/src/components/modal/addCommunityCard/previewBookInfoPagination.tsx
@@ -48,7 +48,7 @@ function PreviewBookInfoPagination({ search }: { search: string}) {
 
   return (
     <>
-      <div className="flex w-[608px] justify-between mobile:w-291">
+      <div className="flex w-[608px] justify-start gap-20 mobile:w-291 mobile:gap-6">
         {(bookOverviews && !chooseBook) &&
           bookOverviews?.map((bookOverview, index) => (
             <PreviewBookInfo

--- a/src/components/modal/addCommunityCard/previewBookInfoPagination.tsx
+++ b/src/components/modal/addCommunityCard/previewBookInfoPagination.tsx
@@ -44,7 +44,7 @@ function PreviewBookInfoPagination({ search }: { search: string}) {
     setBookOverviews(data?.books);
   }, [data]);
   
-  if(!data) return <NoData />;
+  if(!data || search.length === 0) return <NoData />;
 
   return (
     <>

--- a/src/components/modal/addCommunityCard/previewBookInfoPagination.tsx
+++ b/src/components/modal/addCommunityCard/previewBookInfoPagination.tsx
@@ -6,6 +6,7 @@ import { useGetBook, useGetPageBook } from '@/api/book';
 import { useEffect, useState } from 'react';
 import { BookData} from '@/types/api/book';
 import NoData from '@/components/modal/addCommunityCard/noData';
+import SkeletonPreviewBookInfo from '@/components/skeleton/previewBookInfo/skeleton';
 
 function PreviewBookInfoPagination({ search }: { search: string}) {
   const [CurrentPage] = useAtom(CurrentPageStateAtom);
@@ -43,8 +44,8 @@ function PreviewBookInfoPagination({ search }: { search: string}) {
   useEffect(() => {
     setBookOverviews(data?.books);
   }, [data]);
-  
-  if(!data || search.length === 0) return <NoData />;
+
+  if(!data || search.length === 0 ) return <NoData />;
 
   return (
     <>
@@ -62,7 +63,7 @@ function PreviewBookInfoPagination({ search }: { search: string}) {
               community={true}
               onClick={() => handleChooseBook(bookOverview.bookId)}
             />
-          ))}
+          ))} 
         {(chooseBook ) && (
           <PreviewBookInfo
             size="xs"


### PR DESCRIPTION
## 구현사항
책 두권만 있을때 양쪽 정렬이 되어 변경했어요
- [x] justify-between => justify-start, gap 추가 

## 스크린샷
(수정전)
![image](https://github.com/bookstore-README/front_bookstore-README/assets/138510303/8f31a28d-1fac-41b3-b15e-5676bdc96706)
(수정후)
<img width="330" alt="스크린샷 2024-02-28 오전 2 55 24" src="https://github.com/bookstore-README/front_bookstore-README/assets/138510303/dc5c2d6d-f620-47f7-b062-dbc7703f445b">


##### close #448
