### PR TITLE
[#453]  카테고리, 베스트 신간에 리액트 쿼리 캐시 활용

### DIFF
--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -7,6 +7,8 @@ interface GetBookOption {
   endpoint?: string;
   params?: BookParams;
   enabled?: any;
+  staleTime?: number; // 초 단위로 받음
+  gcTime?: number; // 초 단위로 받음
 }
 
 //책 전체 가져오기, 도서 단일 조회
@@ -19,22 +21,22 @@ export const getBook = async (option: GetBookOption) => {
 };
 
 export const useGetBook = (option: GetBookOption) => {
-  return useFetch(QUERY_KEY.book, getBook, option, option?.enabled);
+  const { enabled, staleTime, gcTime } = option;
+  return useFetch(QUERY_KEY.book, getBook, option, enabled, staleTime, gcTime);
 };
 
 //책 전체 infinite, pagination 둘다 가능
-const getPageBook = async (params : BookParamsV2 ) => {
+const getPageBook = async (params: BookParamsV2) => {
   const result = await instance.get(`book/v2`, {
     params,
-  })
+  });
 
   return result.data;
-}
+};
 
-export const useGetPageBook = (params : BookParamsV2) => {
-  return useFetch(QUERY_KEY.book, getPageBook, params, params?.enabled)
-}
-
+export const useGetPageBook = (params: BookParamsV2) => {
+  return useFetch(QUERY_KEY.book, getPageBook, params, params?.enabled);
+};
 
 //도서 조회수 증가
 const putBookView = async (option: putBookPath) => {
@@ -47,14 +49,15 @@ export const usePutBook = (option: putBookPath) => {
   return useUpdate(putBookView, option);
 };
 
-
 // http://15.165.141.22:8080/book/favorite?categoryId=1%2C2%2C3&isRandom=false
 
-
 // 랜덤하게 Book 100권가져오기
-export const getRandomBookList = async (categoryId:string, isRandom:boolean) => {
-  const result = await instance.get(`/book/favorite?categoryId=${encodeURI(categoryId)}&isRandom=${isRandom}`)
-  return result.data
+export const getRandomBookList = async (
+  categoryId: string,
+  isRandom: boolean,
+) => {
+  const result = await instance.get(
+    `/book/favorite?categoryId=${encodeURI(categoryId)}&isRandom=${isRandom}`,
+  );
+  return result.data;
 };
-
-

--- a/src/hooks/useCustomInfiniteQuery.ts
+++ b/src/hooks/useCustomInfiniteQuery.ts
@@ -1,7 +1,11 @@
 // 무한 스크롤 데이터를 불러오는 훅
 
-import { useEffect } from "react";
-import { GetNextPageParamFunction, InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect } from 'react';
+import {
+  GetNextPageParamFunction,
+  InfiniteData,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
 
 interface useCustomInfiniteQueryProps {
   endpoint?: string;
@@ -13,8 +17,8 @@ interface useCustomInfiniteQueryProps {
   sort?: string;
   ascending?: boolean;
   refetchTrigger?: boolean;
-  getNextPageParamsFunc: GetNextPageParamFunction<number, any>
-  selectFunc?: ((data: InfiniteData<any, number>) => any[]);
+  getNextPageParamsFunc: GetNextPageParamFunction<number, any>;
+  selectFunc?: (data: InfiniteData<any, number>) => any[];
 }
 
 function useCustomInfiniteQuery({
@@ -53,9 +57,9 @@ function useCustomInfiniteQuery({
     if (refetchTrigger && !isRefetching && hasNextPage) {
       fetchNextPage();
     }
-  }, [refetchTrigger, isRefetching, hasNextPage])
+  }, [refetchTrigger, isRefetching, hasNextPage]);
 
-  return {data, isFetchingNextPage, isRefetching, hasNextPage };
+  return { data, isFetchingNextPage, isRefetching, hasNextPage };
 }
 
-export default useCustomInfiniteQuery
+export default useCustomInfiniteQuery;

--- a/src/pages/domestic/[category]/bestseller/index.tsx
+++ b/src/pages/domestic/[category]/bestseller/index.tsx
@@ -13,6 +13,8 @@ function BestSellerPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/domestic/[category]/index.tsx
+++ b/src/pages/domestic/[category]/index.tsx
@@ -19,6 +19,8 @@ function CategoryPage() {
     params: {
       ...INITIAL_PARAMS,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
   const { data: bestsellers } = useGetBook({
     endpoint: `${categoryId}/sub`,
@@ -28,6 +30,8 @@ function CategoryPage() {
       sort: 'BESTSELLER',
       ascending: false,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
   const bestList: Array<BookData> = bestsellers ? bestsellers.data.books : [];
 

--- a/src/pages/domestic/[category]/newest/index.tsx
+++ b/src/pages/domestic/[category]/newest/index.tsx
@@ -13,6 +13,8 @@ function NewestPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/domestic/bestseller/index.tsx
+++ b/src/pages/domestic/bestseller/index.tsx
@@ -14,6 +14,8 @@ function BestSellerPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/domestic/index.tsx
+++ b/src/pages/domestic/index.tsx
@@ -28,6 +28,8 @@ export default function DomesticPage() {
     params: {
       ...INITIAL_PARAMS,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
 
   return (

--- a/src/pages/domestic/newest/index.tsx
+++ b/src/pages/domestic/newest/index.tsx
@@ -13,6 +13,8 @@ function NewestPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/foreign/[category]/bestseller/index.tsx
+++ b/src/pages/foreign/[category]/bestseller/index.tsx
@@ -13,6 +13,8 @@ function BestSellerPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/foreign/[category]/index.tsx
+++ b/src/pages/foreign/[category]/index.tsx
@@ -19,6 +19,8 @@ function CategoryPage() {
     params: {
       ...INITIAL_PARAMS,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
   const { data: bestsellers } = useGetBook({
     endpoint: `${categoryId}/sub`,
@@ -28,6 +30,8 @@ function CategoryPage() {
       sort: 'BESTSELLER',
       ascending: false,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
   const bestList: Array<BookData> = bestsellers ? bestsellers.data.books : [];
 

--- a/src/pages/foreign/[category]/newest/index.tsx
+++ b/src/pages/foreign/[category]/newest/index.tsx
@@ -13,6 +13,8 @@ function NewestPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${categoryId}/sub`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/foreign/bestseller/index.tsx
+++ b/src/pages/foreign/bestseller/index.tsx
@@ -13,6 +13,8 @@ function BestSellerPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/pages/foreign/index.tsx
+++ b/src/pages/foreign/index.tsx
@@ -19,6 +19,8 @@ export default function ForeignPage() {
     params: {
       ...INITIAL_PARAMS,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
 
   const { data: bestsellers } = useGetBook({
@@ -29,6 +31,8 @@ export default function ForeignPage() {
       sort: 'BESTSELLER',
       ascending: false,
     },
+    staleTime: 60,
+    gcTime: 120,
   });
   const bestList: Array<BookData> = bestsellers ? bestsellers.data.books : [];
   return (

--- a/src/pages/foreign/newest/index.tsx
+++ b/src/pages/foreign/newest/index.tsx
@@ -13,6 +13,8 @@ function NewestPage() {
   const { data, isLoading } = useGetBook({
     endpoint: `${mainId}/main`,
     params: INITIAL_PARAMS,
+    staleTime: 60,
+    gcTime: 120,
   });
   const bookData: BookData[] = data?.data?.books ?? [];
 

--- a/src/utils/reactQuery.ts
+++ b/src/utils/reactQuery.ts
@@ -5,11 +5,15 @@ export const useFetch = <T>(
   queryFn: (option: T) => Promise<any>,
   params: T,
   enabled?: any,
+  staleTime?: number, // 초 단위로 받음
+  gcTime?: number, // 초 단위로 받음
 ) => {
   const context = useQuery({
     queryKey: [queryKey, params],
     queryFn: () => queryFn(params),
     enabled: enabled ? !!`${enabled}` : true,
+    staleTime: staleTime ? staleTime * 1000 : 0, // 기본값 0
+    gcTime: gcTime ? gcTime * 1000 : 300000, // 기본값 5분
   });
 
   return context;


### PR DESCRIPTION
## 구현사항

- 카테고리 / 베스트/ 신간 페이지에 리액트 쿼리 캐시를 활용해서, get 요청을 줄였어요.
- useGetBook, useFetch 함수에서 옵셔널로 staleTime과 gcTime을 받아서 사용합니다.

모든 페이지에는 적용을 못했습니다 ㅠㅠ 혹시 구현한 페이지에 적용을 원하신다면 사용방법 보시고 추후 리팩토링 해보셔용
일단 도서데이터를 많이 불러오는 페이지에 우선적용했습니다....만 무한스크롤(useInfiniteQuery)을 사용하는 곳에서는 staleTime과 gcTime 적용이 안된다고 해서 못했습니다..

## 사용방법

### useFetch

useFetch 훅에서는 staleTime과 gcTime을 옵셔널로 받습니다.
기본값은 기본 설정값인 statleTime = 0, gcTime = 5분 입니다.
staleTime과 gcTime이 없으면 기본값이 적용됩니다.
infinity는 과도한 데이터 캐싱이 될 수 있다고 하여서 일단 페이지 마다 staleTime 1분, gcTime 2분을 임의로 설정했습니다.
<img width="707" alt="스크린샷 2024-02-28 오후 3 50 15" src="https://github.com/bookstore-README/front_bookstore-README/assets/120437902/2ce490af-afa0-4862-81c9-145424491979">

![스크린샷 2024-02-28 오후 3 37 55](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/ae7bf92b-9787-4c68-b39c-e6eed7f04f5f)
***
### useGetBook
기존 enabled외에도  staleTime과 gcTime을 추가로 넘겨줄 수 있도록 하였습니당
![스크린샷 2024-02-28 오후 3 47 54](https://github.com/bookstore-README/front_bookstore-README/assets/120437902/67ad45b7-fb0f-4296-9d2d-828e53ffda61)

## 스크린샷


도서데이터를 처음 불러온 이후로는 1분간 get 요청을 보내지 않습니다.
찜버튼 눌렀을때는 다시 불러옵니다.

https://github.com/bookstore-README/front_bookstore-README/assets/120437902/19d00839-430a-42c0-87ca-1603f5a191fb



##### close #453 
