### PR TITLE
[#455] header border 수정

### DIFF
--- a/src/components/header/categoryTab.tsx
+++ b/src/components/header/categoryTab.tsx
@@ -37,42 +37,44 @@ function CategoryTab() {
   };
 
   return (
-    <div className="z-100 relative mx-15 flex min-h-fit flex-wrap rounded-md border border-t-0 border-gray-1 bg-white opacity-100 mobile:w-280 tablet:mx-30 tablet:h-437 tablet:w-[600px] pc:mx-60 pc:h-437 pc:w-[600px]">
-      <div className="flex w-full justify-between border-b border-gray-1">
-        <div className="relative mx-30 flex h-60 items-center gap-60 mobile:mx-20 mobile:h-50 mobile:gap-35">
-          <CategoryButton
-            label="국내도서"
-            onClick={() => {
-              handleCategoryClick('domestic');
-            }}
-            selected={selectedCategory == 'domestic'}
-          />
+    <div className="mx-auto max-w-[1200px]">
+      <div className="z-100 relative mx-15 flex min-h-fit flex-wrap rounded-md border border-t-0 border-gray-1 bg-white opacity-100 mobile:w-280 tablet:mx-30 tablet:h-437 tablet:w-[600px] pc:mx-60 pc:h-437 pc:w-[600px]">
+        <div className="flex w-full justify-between border-b border-gray-1">
+          <div className="relative mx-30 flex h-60 items-center gap-60 mobile:mx-20 mobile:h-50 mobile:gap-35">
+            <CategoryButton
+              label="국내도서"
+              onClick={() => {
+                handleCategoryClick('domestic');
+              }}
+              selected={selectedCategory == 'domestic'}
+            />
 
-          <CategoryButton
-            label="외국도서"
-            onClick={() => {
-              handleCategoryClick('foreign');
-            }}
-            selected={selectedCategory == 'foreign'}
-          />
+            <CategoryButton
+              label="외국도서"
+              onClick={() => {
+                handleCategoryClick('foreign');
+              }}
+              selected={selectedCategory == 'foreign'}
+            />
+          </div>
+          <div className="flex-center mr-30">
+            <SelectedAllButton
+              selectedCategory={selectedCategory}
+              selectedAll={selectedAll}
+            />
+          </div>
         </div>
-        <div className="flex-center mr-30">
-          <SelectedAllButton
-            selectedCategory={selectedCategory}
-            selectedAll={selectedAll}
-          />
+        <div
+          className={`text-13 mx-30 my-20 flex flex-wrap mobile:mx-20 tablet:h-350 pc:h-350 ${getLinkLayoutClass()}`}>
+          {categoryList &&
+            categoryList[selectedCategory]?.map((el, ind) => (
+              <Link
+                href={`/${selectedCategory}${el.link}`}
+                key={el?.categoryId ?? ind}>
+                {el?.subName}
+              </Link>
+            ))}
         </div>
-      </div>
-      <div
-        className={`text-13 mx-30 my-20 flex flex-wrap mobile:mx-20 tablet:h-350 pc:h-350 ${getLinkLayoutClass()}`}>
-        {categoryList &&
-          categoryList[selectedCategory]?.map((el, ind) => (
-            <Link
-              href={`/${selectedCategory}${el.link}`}
-              key={el?.categoryId ?? ind}>
-              {el?.subName}
-            </Link>
-          ))}
       </div>
     </div>
   );

--- a/src/components/header/mypageTab.tsx
+++ b/src/components/header/mypageTab.tsx
@@ -44,8 +44,8 @@ function MyPageTab() {
   };
 
   return (
-    <div>
-      <div className="flex-center h-70 gap-48 border-y border-gray-1 mobile:h-50 mobile:gap-20">
+    <div className="border-b border-gray-1">
+      <div className="flex-center h-70 min-w-fit max-w-[1200px] gap-48 mobile:h-50 mobile:gap-20">
         <TabButton
           selected={selectedTab === 'orderList'}
           onClick={() => handleButtonClick('orderList')}

--- a/src/components/header/navigationTab.tsx
+++ b/src/components/header/navigationTab.tsx
@@ -33,7 +33,7 @@ function NavigationTab({ isLoggedIn }: NavigationTabProps) {
   return (
     <>
       <div
-        className="b flex h-40 min-w-fit max-w-full items-center tablet:h-70
+        className="mx-auto flex h-40 min-w-fit max-w-[1200px] items-center tablet:h-70
           pc:h-70">
         <div className="flex items-center justify-between text-14 tablet:text-16 pc:text-16">
           <div className="mx-16 tablet:mx-30 pc:mx-60">
@@ -54,6 +54,7 @@ function NavigationTab({ isLoggedIn }: NavigationTabProps) {
           </div>
         )}
       </div>
+      <hr className="h-1 border-0 bg-gray-1"></hr>
       {isCategoryTabVisible && <CategoryTab />}
       {isModalOpen && <AddCommunityCard onClick={handleModalOpen} />}
     </>

--- a/src/components/layout/headerLayout.tsx
+++ b/src/components/layout/headerLayout.tsx
@@ -17,10 +17,8 @@ function HeaderLayout({ isLoggedIn, children }: HeaderLayoutProps) {
       className={`sticky top-0 z-50 min-h-fit w-full min-w-fit flex-row bg-white ${isMypage ? 'min-h-fit' : 'h-110 tablet:h-170 pc:h-170'}`}>
       <div className="mx-auto max-w-[1200px]"> {children}</div>
       <hr className="h-1 border-0 bg-gray-1"></hr>
-      <div className="mx-auto max-w-[1200px]">
-        {isMypage ? <MyPageTab /> : <NavigationTab isLoggedIn={isLoggedIn} />}
-      </div>
-      <hr className="h-1 border-0 bg-gray-1"></hr>
+
+      {isMypage ? <MyPageTab /> : <NavigationTab isLoggedIn={isLoggedIn} />}
     </div>
   );
 }


### PR DESCRIPTION
## 구현사항
네비게이션 탭을 열었을 때 hr이 화면 전체를 가로지르는 문제, 마이페이지 탭의 border 길이가 부족한 문제가 있어 수정했습니다. 
- [x] header border 수정

## 사용방법
header border에 문제가 없나 확인해주세요

## 스크린샷
- 변경 전
<img width="1414" alt="스크린샷 2024-02-28 오후 4 19 45" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/de10b6ca-d227-4a2b-bd77-8fe399bc3498">

<img width="1413" alt="스크린샷 2024-02-28 오후 4 30 27" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/b6cb39dd-7e15-45d3-acf2-1f74cb890f94">

- 변경 후
<img width="1410" alt="스크린샷 2024-02-28 오후 4 31 02" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/9db590b6-7635-43e0-ab03-5af1a5670b5d">
<img width="1430" alt="스크린샷 2024-02-28 오후 4 38 47" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/f3d126af-1866-4e78-842d-6436dc50bbbf">





##### close #455