### PR TITLE
[#457] 맞춤도서 섹션 여백 변경

### DIFF
--- a/src/components/container/customSection/customSection.tsx
+++ b/src/components/container/customSection/customSection.tsx
@@ -74,13 +74,13 @@ function CustomSection({ isLoggedIn }: CustomSectionProps) {
       ) : getRandomCustomBookList?.data?.length === 0 ? (
         <VacantCustomLayout />
       ) : (
-        <div className="flex-center w-full max-w-[1200px] mobile:h-[940px] mobile:flex-col tablet:h-[655px] tablet:flex-col pc:flex pc:h-500 pc:items-center">
+        <div className="flex-center w-full max-w-[1200px] mobile:h-[940px] mobile:flex-col tablet:h-[655px] tablet:flex-col pc:flex pc:h-500">
           <GenreSelection
             genreList={genreList}
             selectedGenreId={selectedGenreId}
             setSelectedGenreId={setSelectedGenreId}
           />
-          <div className="mobile:flex-center relative flex  flex-wrap gap-x-30 mobile:mx-15  mobile:mb-60 mobile:mt-40 mobile:w-360 mobile:gap-x-10 mobile:gap-y-35 mobile:pr-15 tablet:mt-63 tablet:gap-x-20 pc:ml-75 pc:mr-60 pc:justify-between">
+          <div className="mobile:flex-center relative flex  flex-wrap gap-x-30 mobile:mx-15  mobile:mb-60 mobile:mt-40 mobile:w-360 mobile:gap-x-10 mobile:gap-y-35 mobile:pr-15 tablet:mt-63 tablet:gap-x-20 pc:justify-between">
             {getRandomCustomBookList.isLoading ? (
               <div></div>
             ) : (

--- a/src/components/container/customSection/genreSelection.tsx
+++ b/src/components/container/customSection/genreSelection.tsx
@@ -14,7 +14,7 @@ function GenreSelection({
   setSelectedGenreId,
 }: GenreSelectionProps) {
   return (
-    <div className="flex-center flex w-260 flex-col gap-8 mobile:mb-3 mobile:mt-60 mobile:w-314 tablet:w-314">
+    <div className="flex-center flex w-260 flex-col gap-8 mobile:mb-3 mobile:mt-60 mobile:w-314 tablet:w-314 pc:mr-75">
       {genreList.length > 0 ? (
         <div className="flex-center mb-30 mt-22 flex h-75 w-full flex-wrap gap-8 ">
           <div className="text-24 font-bold mobile:text-20">


### PR DESCRIPTION
## 구현사항

- [x] 맞춤도서 섹션 여백 변경

## 사용방법

## 스크린샷
- 변경 전
![변경전](https://github.com/bookstore-README/front_bookstore-README/assets/119280160/ec8d61ca-73f6-4996-9a49-317e2f384234)

- 변경 후
<img width="689" alt="스크린샷 2024-02-28 오후 6 35 57" src="https://github.com/bookstore-README/front_bookstore-README/assets/119280160/d7b26e89-384f-4081-b6e6-d1d1ea719a89">



##### close #457
