### PR TITLE
refactor: 메인페이지 신간도서 18개 받아오도록 수정

### DIFF
--- a/src/components/header/categoryTab.tsx
+++ b/src/components/header/categoryTab.tsx
@@ -40,7 +40,7 @@ function CategoryTab() {
     <div className="mx-auto max-w-[1200px]">
       <div className="z-100 relative mx-15 flex min-h-fit flex-wrap rounded-md border border-t-0 border-gray-1 bg-white opacity-100 mobile:w-280 tablet:mx-30 tablet:h-437 tablet:w-[600px] pc:mx-60 pc:h-437 pc:w-[600px]">
         <div className="flex w-full justify-between border-b border-gray-1">
-          <div className="relative mx-30 flex h-60 items-center gap-60 mobile:mx-20 mobile:h-50 mobile:gap-35">
+          <div className="relative mx-60 flex h-60 items-center gap-60 mobile:mx-20 mobile:h-50 mobile:gap-35">
             <CategoryButton
               label="국내도서"
               onClick={() => {
@@ -65,7 +65,7 @@ function CategoryTab() {
           </div>
         </div>
         <div
-          className={`text-13 mx-30 my-20 flex flex-wrap mobile:mx-20 tablet:h-350 pc:h-350 ${getLinkLayoutClass()}`}>
+          className={`text-13 my-20 flex w-full  mobile:mx-20 tablet:mx-30 tablet:ml-60 tablet:h-350 pc:ml-60 pc:mr-56 pc:h-350  ${getLinkLayoutClass()}`}>
           {categoryList &&
             categoryList[selectedCategory]?.map((el, ind) => (
               <Link

--- a/src/components/header/mypageTab.tsx
+++ b/src/components/header/mypageTab.tsx
@@ -44,7 +44,7 @@ function MyPageTab() {
   };
 
   return (
-    <div className="border-b border-gray-1">
+    <div className="flex-col justify-center border-b border-gray-1">
       <div className="flex-center h-70 min-w-fit max-w-[1200px] gap-48 mobile:h-50 mobile:gap-20">
         <TabButton
           selected={selectedTab === 'orderList'}

--- a/src/components/header/navigationTab.tsx
+++ b/src/components/header/navigationTab.tsx
@@ -33,13 +33,13 @@ function NavigationTab({ isLoggedIn }: NavigationTabProps) {
   return (
     <>
       <div
-        className="mx-auto flex h-40 min-w-fit max-w-[1200px] items-center tablet:h-70
-          pc:h-70">
+        className="flex h-40 min-w-fit items-center mobile:max-w-360 mobile:justify-start tablet:h-70
+          pc:mx-auto pc:h-70 pc:max-w-[1200px]">
         <div className="flex items-center justify-between text-14 tablet:text-16 pc:text-16">
-          <div className="mx-16 tablet:mx-30 pc:mx-60">
+          <div className="mx-26 tablet:ml-40 pc:ml-70">
             <CategoryTabButton onClick={toggleCategoryTab} />
           </div>
-          <div className="flex gap-18 tablet:gap-30 pc:gap-40">
+          <div className="flex gap-18 tablet:ml-86 tablet:gap-30 pc:ml-106 pc:gap-40">
             <Link href="/domestic/bestseller"> 베스트</Link>
             <Link href="/domestic/newest"> 신간</Link>
             <CustomBookButton isLoggedIn={isLoggedIn} />

--- a/src/components/header/settingTab.tsx
+++ b/src/components/header/settingTab.tsx
@@ -22,8 +22,8 @@ function SettingTab() {
   };
 
   return (
-    <div>
-      <div className="flex-center h-70 w-full gap-48 border-b border-gray-1 mobile:h-50">
+    <div className="border-t border-gray-1">
+      <div className="flex-center h-69 min-w-fit  max-w-[1200px] gap-48 mobile:h-50">
         <TabButton
           selected={selectedTab === 'editProfile'}
           onClick={() => handleButtonClick('editProfile')}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,7 @@ function Home() {
     endpoint: '0/main',
     params: {
       bookId: '0',
-      limit: '6',
+      limit: '18',
       sort: 'NEWEST',
       ascending: false,
     },


### PR DESCRIPTION
## 구현사항

- 메인페이지 신간도서 캐러셀 화살표가 비활성화 되는게 도서 6개만 받아와서 그렇더라구요! 피그마 시안에 맞춰 18개로 변경했습니다.

## 사용방법

## 스크린샷


https://github.com/bookstore-README/front_bookstore-README/assets/120437902/e60c41b1-e54f-4bd3-95a8-28b93f25d498


##### close #
