### PR TITLE
이벤트 캐러셀 수정

### DIFF
--- a/src/components/carousel/eventCarousel.tsx
+++ b/src/components/carousel/eventCarousel.tsx
@@ -118,7 +118,7 @@ function EventCarousel({
       <div className="flex-center left-30% absolute bottom-20 z-10 h-20 w-100 gap-10 mobile:bottom-8">
         {currList.map((_, idx) => (
           <button
-            className={`h-10 w-10 rounded-full bg-gray-1 hover:bg-primary active:bg-primary ${ButtonActiveIndex === idx ? 'bg-primary' : ''} mobile:h-5 mobile:w-5`}
+            className={`h-10 w-10 rounded-full bg-gray-1 active:bg-primary ${ButtonActiveIndex === idx ? 'bg-primary' : ''} mobile:h-5 mobile:w-5`}
             onClick={() => updateIndex(idx)}
             key={idx}
           />

--- a/src/components/carousel/eventCarousel.tsx
+++ b/src/components/carousel/eventCarousel.tsx
@@ -49,13 +49,12 @@ function EventCarousel({
       const sensitivity = 50; // 터치 이벤트 감지 감도 (좌우 이동 거리)
       if (diff > sensitivity) {
         // 오른쪽으로 슬라이드
-        const newIndex =
-          currIndex === currList.length ? currIndex : currIndex + 1;
+        const newIndex = currIndex === currList.length ? 1 : currIndex + 1;
         setCurrIndex(newIndex);
         setButtonActiveIndex(newIndex - 1);
       } else if (diff < -sensitivity) {
         // 왼쪽으로 슬라이드
-        const newIndex = currIndex === 1 ? 1 : currIndex - 1;
+        const newIndex = currIndex === 1 ? currList.length : currIndex - 1;
         setCurrIndex(newIndex);
         setButtonActiveIndex(newIndex - 1);
       }


### PR DESCRIPTION
## 구현사항

- 모바일버전에서 드래그 하면 이미지가 넘어가도록 수정
- 무한루프로 이미지 변경되도록 수정
- 마우스오버 스타일 삭제
개발자도구에서 클릭한 버튼 스타일이 유지되던 이유가 마우스오버 스타일 때문이였더라구요..
모바일에서도 hover 이벤트와 touch 이벤트가 잘 구분되지 않아서 가끔 눌린채로 유지되는것처럼 보이는걸로 추정합니다.
그래서 그냥 지워버렸긔

## 사용방법

코멘트 참고해주세용

## 스크린샷

https://github.com/bookstore-README/front_bookstore-README/assets/120437902/065e1c75-d83f-4f49-b8e8-1ac4f499a239


##### close #
